### PR TITLE
Install LLVM 13 on Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           clang -v dummy.c
 
       - name: Build native binary
-        run: sbt bindgen/nativeLink
+        run: sbt 'show nativeConfig' bindgen/nativeLink
 
       - name: Upload artifacts
         uses: actions/upload-artifact@master

--- a/build.sbt
+++ b/build.sbt
@@ -362,11 +362,13 @@ def clangInclude: List[String] = {
 }
 
 def llvmLib =
-  linking(ifMac =
-    if (Platform.target.arch == Platform.Arch.x86_64)
-      List("/usr/local/opt/llvm/lib")
-    else
-      List("/opt/homebrew/opt/llvm/lib")
+  linking(
+    ifLinux = (10 to 13).toList.flatMap(v => List(s"/usr/lib/llvm-$v/lib/")),
+    ifMac =
+      if (Platform.target.arch == Platform.Arch.x86_64)
+        List("/usr/local/opt/llvm/lib")
+      else
+        List("/opt/homebrew/opt/llvm/lib")
   )
 
 def sampleBindings(location: File, builder: BindingBuilder) = {

--- a/build/setup_unix.sh
+++ b/build/setup_unix.sh
@@ -12,5 +12,6 @@ else
   wget https://apt.llvm.org/llvm.sh
   chmod +x llvm.sh
   sudo ./llvm.sh 13
+  sudo apt install libclang-13-dev
 fi
 

--- a/build/setup_unix.sh
+++ b/build/setup_unix.sh
@@ -8,6 +8,9 @@ if [ $PLATFORM == "Darwin" ]; then
 else
   echo "It's a linux"
   sudo apt update
-  sudo apt install clang llvm llvm-dev libclang-dev
+  sudo apt install lsb-release wget software-properties-common
+  wget https://apt.llvm.org/llvm.sh
+  chmod +x llvm.sh
+  sudo ./llvm.sh 13
 fi
 


### PR DESCRIPTION
Previously, on ubuntu the clang version we built with was 10, which was failing linkage on even my linux box, which is not super new, but only has LLVM versions from 11 to 13.

I've confirmed that the new version is linked against newer libclang and as such works on my machine:

```
❯ ldd ~/Desktop/bindgen-out
        linux-vdso.so.1 (0x00007fff4030a000)
        libclang-13.so.13 => /lib/x86_64-linux-gnu/libclang-13.so.13 (0x00007ff795412000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007ff79540d000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007ff795408000)
        libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007ff7951ef000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007ff79510b000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007ff7950f1000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007ff794ec7000)
        libLLVM-13.so.1 => /lib/x86_64-linux-gnu/libLLVM-13.so.1 (0x00007ff78f2e3000)
        /lib64/ld-linux-x86-64.so.2 (0x00007ff79736b000)
        libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8 (0x00007ff78f2d7000)
        libedit.so.2 => /lib/x86_64-linux-gnu/libedit.so.2 (0x00007ff78f29e000)
        libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007ff78f282000)
        libtinfo.so.6 => /lib/x86_64-linux-gnu/libtinfo.so.6 (0x00007ff78f251000)
        libxml2.so.2 => /lib/x86_64-linux-gnu/libxml2.so.2 (0x00007ff78f06f000)
        libbsd.so.0 => /lib/x86_64-linux-gnu/libbsd.so.0 (0x00007ff78f057000)
        libicuuc.so.67 => /lib/x86_64-linux-gnu/libicuuc.so.67 (0x00007ff78ee6d000)
        liblzma.so.5 => /lib/x86_64-linux-gnu/liblzma.so.5 (0x00007ff78ee42000)
        libmd.so.0 => /lib/x86_64-linux-gnu/libmd.so.0 (0x00007ff78ee33000)
        libicudata.so.67 => /lib/x86_64-linux-gnu/libicudata.so.67 (0x00007ff78d31a000)
```

This is the binary I downloaded from the last build of this job.
