### PR TITLE
Generate pointer versions of struct passing functions

### DIFF
--- a/bindgen/src/test/scala/TestFunctionRewrites.scala
+++ b/bindgen/src/test/scala/TestFunctionRewrites.scala
@@ -26,7 +26,6 @@ class TestFunctionRewrites:
     zone {
       val t1 = FunctionRewriteStruct(25, 35.0)
       val t2 = FunctionRewriteStruct(15, 40.0)
-      val i = 100
 
       val result = rewrite_bad_func(!t1, !t2)
 
@@ -42,5 +41,23 @@ class TestFunctionRewrites:
 
       assertEquals(25 - 15, rewrite_better_func(!t1, !t2))
       assertEquals(15 - 25, rewrite_better_func(!t2, !t1))
+    }
+
+  @Test def test_pointer_versions(): Unit =
+    zone {
+      val t1 = FunctionRewriteStruct(25, 35.0)
+      val t2 = FunctionRewriteStruct(15, 40.0)
+      val resultPtr = FunctionRewriteStruct()
+      {
+        // this method shouldn't require a Zone!
+        given Zone = ???
+        rewrite_bad_func(t1, t2)(resultPtr)
+
+        assertEquals(35.0 * 40.0, (!resultPtr).b, 0.01f)
+      }
+
+      val result = rewrite_bad_func(t1, t2)
+
+      assertEquals(35.0 * 40.0, result.b, 0.01f)
     }
 end TestFunctionRewrites


### PR DESCRIPTION
Closes #28 

Given the following C function:

```C
typedef struct {
  int i;
  float b;
} FunctionRewriteStruct;

FunctionRewriteStruct rewrite_bad_func(FunctionRewriteStruct a, FunctionRewriteStruct b);
```

We generate 3 Scala versions:

```scala
  def rewrite_bad_func(a: Ptr[FunctionRewriteStruct], b: Ptr[FunctionRewriteStruct])(__return: Ptr[FunctionRewriteStruct]): Unit = 
    __sn_wrap_lib_test_function_rewrites_rewrite_bad_func(a, b, __return)

  def rewrite_bad_func(a: FunctionRewriteStruct, b: FunctionRewriteStruct)(using Zone): FunctionRewriteStruct = 
    val _ptr_0 = alloc[FunctionRewriteStruct](1)
    !_ptr_0 = a
    val _ptr_1 = alloc[FunctionRewriteStruct](1)
    !_ptr_1 = b
    val _ptr_return = alloc[FunctionRewriteStruct](1)
    __sn_wrap_lib_test_function_rewrites_rewrite_bad_func(_ptr_0, _ptr_1, _ptr_return)
    !_ptr_return

  def rewrite_bad_func(a: Ptr[FunctionRewriteStruct], b: Ptr[FunctionRewriteStruct])(using Zone): FunctionRewriteStruct = 
    val _ptr_return = alloc[FunctionRewriteStruct](1)
    __sn_wrap_lib_test_function_rewrites_rewrite_bad_func(a, b, _ptr_return)
    !_ptr_return
```

1. One that looks exactly like the C version, and allocates new memory for **all** arguments + return type
2. One that takes arguments by reference, only allocating for return value
3. One that takes everything by reference, with no allocations
