### PR TITLE
Compress memory allocations for repeated parameters

### DIFF
--- a/bindgen/src/test/resources/scala-native/function_rewrites.c
+++ b/bindgen/src/test/resources/scala-native/function_rewrites.c
@@ -1,9 +1,9 @@
 #include "function_rewrites.h"
-#include "string.h"
 #include "stdlib.h"
+#include "string.h"
 
 FunctionRewriteStruct rewrite_bad_func(FunctionRewriteStruct x,
-                                        FunctionRewriteStruct y) {
+                                       FunctionRewriteStruct y) {
   FunctionRewriteStruct result;
 
   result.b = x.b * y.b;
@@ -14,12 +14,23 @@ FunctionRewriteStruct rewrite_bad_func(FunctionRewriteStruct x,
 int rewrite_better_func(FunctionRewriteStruct a, FunctionRewriteStruct b) {
   return a.i - b.i;
 }
-FunctionRewriteStruct* rewrite_good_func(FunctionRewriteStruct *a,
-                                 FunctionRewriteStruct *b, int i) {
+FunctionRewriteStruct *rewrite_good_func(FunctionRewriteStruct *a,
+                                         FunctionRewriteStruct *b, int i) {
   FunctionRewriteStruct *res = malloc(sizeof(FunctionRewriteStruct));
 
-  res->b = a->b * i + b->b * i; 
-  res->i = a->i * i - b->i * i; 
+  res->b = a->b * i + b->b * i;
+  res->i = a->i * i - b->i * i;
 
   return res;
+}
+
+FunctionRewriteStruct rewrite_without_allocations(FunctionRewriteStruct a,
+                                                  FunctionRewriteStruct b,
+                                                  AllocationTest c, int i) {
+
+  FunctionRewriteStruct result;
+
+  result.i = a.i + b.i + c.i;
+
+  return result;
 }

--- a/bindgen/src/test/resources/scala-native/function_rewrites.h
+++ b/bindgen/src/test/resources/scala-native/function_rewrites.h
@@ -3,6 +3,17 @@ typedef struct {
   float b;
 } FunctionRewriteStruct;
 
-FunctionRewriteStruct rewrite_bad_func(FunctionRewriteStruct a, FunctionRewriteStruct b);
+typedef struct {
+  char *str;
+  int i;
+} AllocationTest;
+
+FunctionRewriteStruct rewrite_bad_func(FunctionRewriteStruct a,
+                                       FunctionRewriteStruct b);
 int rewrite_better_func(FunctionRewriteStruct a, FunctionRewriteStruct b);
-FunctionRewriteStruct* rewrite_good_func(FunctionRewriteStruct *a, FunctionRewriteStruct *b, int i);
+FunctionRewriteStruct *rewrite_good_func(FunctionRewriteStruct *a,
+                                         FunctionRewriteStruct *b, int i);
+FunctionRewriteStruct rewrite_without_allocations(FunctionRewriteStruct a,
+                                                  FunctionRewriteStruct b,
+                                                  AllocationTest c,
+                                                  int i);


### PR DESCRIPTION
Closes #27 

- Reduce the number of calls to `alloc` when parameter types are repeated. 
- Add tests that instrument local Zone allocations