### PR TITLE
Detection of Clang include paths + Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ env:
   JAVA_OPTS: "-Xmx2G"
   SN_RELEASE: fast
   JABBA_INDEX: 'https://github.com/typelevel/jdk-index/raw/main/index.json'
-  CLANG_VERSION: 12
 
 jobs:
   build:
@@ -21,7 +20,7 @@ jobs:
         include:
           - os: macos-latest
             uploaded_filename: sn-bindgen-osx-x86_64
-            llvmBinPath: /usr/local/opt/llvm/include
+            llvmBinPath: /usr/local/opt/llvm/bin
 
           - os: ubuntu-latest
             uploaded_filename: sn-bindgen-linux-x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,11 @@ jobs:
         include:
           - os: macos-latest
             uploaded_filename: sn-bindgen-osx-x86_64
+            llvmBinPath: /usr/local/opt/llvm/include
+
           - os: ubuntu-latest
             uploaded_filename: sn-bindgen-linux-x86_64
+            llvmBinPath: /usr/lib/llvm-13/bin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -42,9 +45,13 @@ jobs:
 
       - name: Run tests
         run: sbt 'show nativeConfig' ci
+        env: 
+          LLVM_BIN: ${{ matrix.llvmBinPath }}
       
       - name: Compile examples
         run: sbt examples/compile
+        env: 
+          LLVM_BIN: ${{ matrix.llvmBinPath }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@master

--- a/bindgen/src/main/scala/render/enumeration.scala
+++ b/bindgen/src/main/scala/render/enumeration.scala
@@ -29,7 +29,7 @@ def enumeration(model: Def.Enum, line: Appender)(using
       )
     end if
     model.values.foreach { case (constName, value) =>
-      val lhs = s"val $constName"
+      val lhs = s"val ${escape(constName)}"
       val rhs = "define(" + value.toString + ")"
 
       line(lhs + " = " + rhs)

--- a/bindgen/src/main/scala/render/utils.scala
+++ b/bindgen/src/main/scala/render/utils.scala
@@ -7,7 +7,8 @@ import scala.scalanative.annotation.alwaysinline
 import scala.collection.mutable.ListBuffer
 
 def escape(name: String) =
-  val keywords = Set("type", "val", "class", "object", "null", "match")
+  val keywords =
+    Set("type", "val", "class", "object", "null", "match", "true", "false")
   if keywords.contains(name) then s"`$name`" else name
 
 case class Error(msg: String) extends Exception(msg)

--- a/bindgen/src/test/resources/scala-native/built_in_types.h
+++ b/bindgen/src/test/resources/scala-native/built_in_types.h
@@ -1,6 +1,10 @@
 #include <stdio.h>
 #include <time.h>
 
+#ifdef _WIN32
+typedef unsigned long ssize_t;
+#endif
+
 typedef size_t Test_size_t;
 typedef ssize_t Test_ssize_t;
 typedef time_t Test_time_t;

--- a/build.sbt
+++ b/build.sbt
@@ -412,7 +412,7 @@ def sampleBindings(location: File, builder: BindingBuilder, ci: ClangInfo) = {
     llvmInclude ++ clangInclude
   )
 
-  if (Platform.target.os != Platform.OS.Linux)
+  if (Platform.target.os == Platform.OS.MacOS)
     define(
       location /
         "curl.h",

--- a/build.sbt
+++ b/build.sbt
@@ -339,10 +339,13 @@ def usesLibClang(conf: NativeConfig) = {
 
   conf
     .withLinkingOptions(
-      conf.linkingOptions ++ Seq("-l" + libraryName) ++ detected.llvmLib
-        .map("-L" + _)
+      conf.linkingOptions ++
+        Seq("-l" + libraryName) ++
+        detected.llvmLib.map("-L" + _)
     )
-    .withCompileOptions(detected.llvmInclude.map("-I" + _))
+    .withCompileOptions(
+      conf.compileOptions ++ detected.llvmInclude.map("-I" + _)
+    )
 }
 
 def includes(
@@ -371,31 +374,6 @@ def linking(
     case _                   => Nil
   }
 }.map(s => s"-L$s")
-
-def llvmInclude: List[String] = {
-  includes(
-    ifLinux =
-      (10 to 13).toList.flatMap(v => List(s"/usr/lib/llvm-$v/include/")),
-    ifMac =
-      List("/opt/homebrew/opt/llvm/include", "/usr/local/opt/llvm/include")
-  )
-}
-
-/* def clangInclude: List[String] = { */
-/*   includes( */
-/*     all = Platform.clangInfo.includePaths */
-/*   ) */
-/* } */
-
-def llvmLib =
-  linking(
-    ifLinux = (10 to 13).toList.flatMap(v => List(s"/usr/lib/llvm-$v/lib/")),
-    ifMac =
-      if (Platform.target.arch == Platform.Arch.x86_64)
-        List("/usr/local/opt/llvm/lib")
-      else
-        List("/opt/homebrew/opt/llvm/lib")
-  )
 
 def sampleBindings(location: File, builder: BindingBuilder, ci: ClangInfo) = {
   import builder.define

--- a/build.sbt
+++ b/build.sbt
@@ -325,7 +325,8 @@ def usesLibClang(conf: NativeConfig) =
 def includes(
     ifLinux: List[String] = Nil,
     ifMac: List[String] = Nil,
-    ifWindows: List[String] = Nil
+    ifWindows: List[String] = Nil,
+    all: List[String] = Nil
 ): List[String] = {
   Platform.target.os match {
     case Platform.OS.Linux   => ifLinux
@@ -333,7 +334,7 @@ def includes(
     case Platform.OS.Windows => ifWindows
     case _                   => Nil
   }
-}.filter(s => Paths.get(s).toFile.exists).map(s => s"-I$s")
+}.++(all).filter(s => Paths.get(s).toFile.exists).map(s => s"-I$s")
 
 def linking(
     ifLinux: List[String] = Nil,
@@ -349,6 +350,7 @@ def linking(
 }.map(s => s"-L$s")
 
 def llvmInclude: List[String] = {
+  println(Platform.clangInfo)
   includes(
     ifLinux =
       (10 to 13).toList.flatMap(v => List(s"/usr/lib/llvm-$v/include/")),
@@ -358,23 +360,8 @@ def llvmInclude: List[String] = {
 }
 
 def clangInclude: List[String] = {
-  val majorVersion = sys.env.getOrElse("CLANG_VERSION", "13")
   includes(
-    ifMac =
-      if (Platform.target.arch == Platform.Arch.x86_64)
-        List(
-          // on X86 macs
-          s"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/$majorVersion.0.0/include",
-          "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include",
-          "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include"
-        )
-      else
-        List(
-          // on M1 macs
-          s"/Library/Developer/CommandLineTools/usr/lib/clang/$majorVersion.0.0/include",
-          "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include",
-          "/Library/Developer/CommandLineTools/usr/include"
-        )
+    all = Platform.clangInfo.includePaths
   )
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -76,6 +76,7 @@ lazy val bindgen = project
   .settings(
     Test / nativeLink / artifactPath := crossTarget.value / "test-bindgen-out"
   )
+  .settings(clangDetection)
   .settings(
     moduleName := "bindgen",
     libraryDependencies += ("com.monovore" %%% "decline" % Versions.decline cross CrossVersion.for3Use2_13)
@@ -350,7 +351,6 @@ def linking(
 }.map(s => s"-L$s")
 
 def llvmInclude: List[String] = {
-  println(Platform.clangInfo)
   includes(
     ifLinux =
       (10 to 13).toList.flatMap(v => List(s"/usr/lib/llvm-$v/include/")),
@@ -453,6 +453,14 @@ versionDump := {
   IO.write(file, (Compile / version).value)
 }
 
+lazy val clangInfo = taskKey[Platform.ClangInfo]("")
+
+lazy val clangDetection = Seq(clangInfo := {
+  val path = nativeClang.value.toPath()
+
+  Platform.detectClangInfo(path)
+})
+
 addCommandAlias(
   "ci",
   "scalafmtCheckAll; scalafmtSbtCheck; test; plugin/scripted"
@@ -478,5 +486,3 @@ inThisBuild(
     )
   )
 )
-
-lazy val fetchedBinary = taskKey[Unit]("")

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ import java.nio.file.Paths
 
 lazy val Versions = new {
   val decline = "2.2.0"
-  val scalaNative = "0.4.3"
+  val scalaNative = nativeVersion
   val junit = "0.11"
 
   val Scala212 = "2.12.15"
@@ -318,10 +318,16 @@ def environmentConfiguration(conf: NativeConfig): NativeConfig = {
   else conf
 }
 
-def usesLibClang(conf: NativeConfig) =
+def usesLibClang(conf: NativeConfig) = {
+  val libraryName =
+    if (Platform.os == Platform.OS.Windows) "libclang" else "clang"
+
   conf
-    .withLinkingOptions(conf.linkingOptions ++ Seq("-lclang") ++ llvmLib)
+    .withLinkingOptions(
+      conf.linkingOptions ++ Seq("-l" + libraryName) ++ llvmLib
+    )
     .withCompileOptions(llvmInclude)
+}
 
 def includes(
     ifLinux: List[String] = Nil,

--- a/interface/src/main/scala/Interface.scala
+++ b/interface/src/main/scala/Interface.scala
@@ -149,7 +149,7 @@ class BindingBuilder(binary: File) {
 
       val destination = to / destinationFilename
 
-      val cmd = binary.toString + " " + binding.toCommand(lang)
+      val cmd = binary.toString :: binding.toCommand(lang)
 
       System.err.println(s"Executing $cmd")
       System.err.println(s"Writing to $destination")

--- a/interface/src/main/scala/Interface.scala
+++ b/interface/src/main/scala/Interface.scala
@@ -78,27 +78,36 @@ class BindingBuilder(binary: File) {
       cImports: List[String],
       clangFlags: List[String]
   ) {
-    def toCommand(lang: BindingLang): String = {
+    def toCommand(lang: BindingLang): List[String] = {
       val sb = List.newBuilder[String]
-      sb += s"--header $headerFile"
-      sb += s"--package $packageName"
+
+      def arg(name: String, value: String) =
+        sb ++= Seq(s"--$name", value)
+
+      def flag(name: String) =
+        sb += s"--$name"
+
+      arg(
+        "header",
+        headerFile.toPath().toAbsolutePath().toString
+      )
+      arg("package", packageName)
       linkName.foreach { link =>
-        sb += s"--link-name $link"
+        arg("link-name", link)
       }
       cImports.foreach { cimp =>
-        sb += s"--c-import $cimp"
+        arg("c-import", cimp)
       }
       clangFlags.foreach { clangFlag =>
-        sb += s"--clang $clangFlag"
+        arg("clang", clangFlag)
       }
-
-      sb += s" --${level.str}"
+      flag(level.str)
       if (lang == BindingLang.Scala)
-        sb += "--scala"
+        flag("scala")
       else
-        sb += "--c"
+        flag("c")
 
-      sb.result.mkString(" ")
+      sb.result()
     }
   }
 

--- a/interface/src/main/scala/Platform.scala
+++ b/interface/src/main/scala/Platform.scala
@@ -108,9 +108,15 @@ object ClangDetector {
 
     def addLLVMFolders(conf: Platform.ClangInfo) = Platform.os match {
       case MacOS =>
-        conf.copy(llvmInclude =
-          List("/opt/homebrew/opt/llvm/include", "/usr/local/opt/llvm/include")
-        )
+        conf
+          .copy(
+            llvmInclude = List(
+              "/opt/homebrew/opt/llvm/include",
+              "/usr/local/opt/llvm/include"
+            ),
+            llvmLib =
+              List("/usr/local/opt/llvm/lib", "/opt/homebrew/opt/llvm/lib")
+          )
       case Linux | Windows =>
         // <llvm-path>/bin/clang
         val realPath = path.toRealPath()

--- a/interface/src/main/scala/Platform.scala
+++ b/interface/src/main/scala/Platform.scala
@@ -115,7 +115,7 @@ object ClangDetector {
         // <llvm-path>/bin/clang
         val realPath = path.toRealPath()
         val binFolder = realPath.getParent()
-        val llvmFolder = realPath.getParent()
+        val llvmFolder = binFolder.getParent()
 
         if (llvmFolder.toFile.exists())
           conf.copy(

--- a/interface/src/main/scala/Platform.scala
+++ b/interface/src/main/scala/Platform.scala
@@ -64,6 +64,7 @@ object Platform {
 
   def detectOs(osNameProp: String): OS = normalise(osNameProp) match {
     case p if p.startsWith("linux")                         => OS.Linux
+    case p if p.startsWith("windows")                       => OS.Windows
     case p if p.startsWith("osx") || p.startsWith("macosx") => OS.MacOS
     case _                                                  => OS.Unknown
   }
@@ -100,7 +101,10 @@ object ClangDetector {
       (e: String) => stderr += e
     )
 
-    scala.sys.process.Process(cmd).run(logger).exitValue()
+    val exitCode = scala.sys.process.Process(cmd).run(logger).exitValue()
+
+    if (exitCode != 0)
+      stderr.result().foreach(println)
 
     def addLLVMFolders(conf: Platform.ClangInfo) = Platform.os match {
       case MacOS =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.0
+sbt.version=1.6.1


### PR DESCRIPTION
- Interrogate selected clang binary to find out various include paths
- Remove hardcoded paths (apart from macos) from the build
- Force correct path to LLVM clang on all platforms
- **exciting**: confirmed that tests and examples now work on Windows! I'm developing this in a VM, so full blown CI will have to wait.
