### PR TITLE
Consistent uint*_t/int*_t alias rendering

### DIFF
--- a/bindgen/src/main/scala/BuiltinType.scala
+++ b/bindgen/src/main/scala/BuiltinType.scala
@@ -10,6 +10,8 @@ private def integral(base: IntegralBase, st: SignType) =
   CType.NumericIntegral(base, st)
 
 private def _unsafe(typ: String) = s"scala.scalanative.unsafe.$typ"
+private def _scala(typ: String) = s"scala.$typ"
+private def _unsigned(typ: String) = s"scala.scalanative.unsigned.$typ"
 private def _libc(typ: String) = s"scala.scalanative.libc.$typ"
 private def _posix(typ: String) = s"scala.scalanative.posix.$typ"
 private def size[T](using t: Tag[T]) = t.size
@@ -54,6 +56,12 @@ object BuiltinType:
     apply[sockaddr](
       "sockaddr",
       "scala.scalanative.posix.sys.socket.sockaddr"
-    )
+    ),
+    apply[UByte]("uint8_t", _unsigned("UByte")),
+    apply[UShort]("uint16_t", _unsigned("UShort")),
+    apply[UInt]("uint32_t", _unsigned("UInt")),
+    apply[CChar]("int8_t", _unsafe("CChar")),
+    apply[Short]("int16_t", _scala("Short")),
+    apply[CInt]("int32_t", _unsafe("CInt"))
   )
 end BuiltinType

--- a/bindgen/src/main/scala/render/alias.scala
+++ b/bindgen/src/main/scala/render/alias.scala
@@ -11,12 +11,6 @@ def alias(model: Def.Alias, line: Appender)(using AliasResolver, Config) =
     case _: Reference | _: Function | Void => false
     case _                                 => true
 
-  // model.underlying match
-  //   case Pointer(Function(retType, params)) =>
-  //     trace(s"Checking $model for cycles: ")
-  //     trace(isCyclical(model.underlying, model.name))
-  //   case _ =>
-
   val modifier = if isOpaque then "opaque " else ""
   line(s"${modifier}type ${model.name} = $underlyingType")
   line(s"object ${model.name}: ")

--- a/bindgen/src/test/resources/scala-native/built_in_types.h
+++ b/bindgen/src/test/resources/scala-native/built_in_types.h
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <time.h>
+#include <stdint.h>
 
 #ifdef _WIN32
 typedef unsigned long ssize_t;
@@ -10,3 +11,13 @@ typedef ssize_t Test_ssize_t;
 typedef time_t Test_time_t;
 typedef fpos_t Test_fpos_t;
 typedef va_list Test_va_list;
+
+struct SpecialIntTypes {
+  int8_t i8;
+  int16_t i16;
+  int32_t i32;
+
+  uint8_t u8;
+  uint16_t u16;
+  uint32_t u32;
+};

--- a/bindgen/src/test/scala/TestBuiltinTypes.scala
+++ b/bindgen/src/test/scala/TestBuiltinTypes.scala
@@ -22,4 +22,24 @@ class TestBuiltInTypes:
     summon[Test_time_t =:= time.time_t]
     summon[Test_fpos_t =:= libc.stdio.fpos_t]
   end correct_tags
+
+  @Test def consistent_uint_types(): Unit =
+    // this should compile
+    zone {
+      val st = !SpecialIntTypes(
+        i8 = -8.toByte,
+        i16 = -16.toShort,
+        i32 = -32,
+        u8 = 8.toUByte,
+        u16 = 16.toUShort,
+        u32 = 32.toUInt
+      )
+
+      assertEquals(-8, st.i8.toInt)
+      assertEquals(-16, st.i16.toInt)
+      assertEquals(-32, st.i32.toInt)
+      assertEquals(8, st.u8.toInt)
+      assertEquals(16, st.u16.toInt)
+      assertEquals(32, st.u32.toInt)
+    }
 end TestBuiltInTypes

--- a/interface/src/main/scala/Interface.scala
+++ b/interface/src/main/scala/Interface.scala
@@ -178,7 +178,7 @@ class BindingBuilder(binary: File) {
           )
 
           buf.result().foreach { l =>
-            System.err.println(s"/*$code*/  " + l + System.lineSeparator())
+            System.err.println(s"/*$code*/  " + l)
           }
 
           throw new Exception(


### PR DESCRIPTION
Problem:
- On MacOS, `uin32_t` is returned by clang as direct alias of `unsigned int`
- On Linux, it's an alias to `__uint32_t`, which is an alias of unsigned int.

We bite the bullet and special case these types.