### PR TITLE
Fam and recursive fixes

### DIFF
--- a/bindgen/src/main/scala/Def.scala
+++ b/bindgen/src/main/scala/Def.scala
@@ -58,6 +58,7 @@ object EnumName extends OpaqueString[EnumName]
 
 opaque type StructName = String
 object StructName extends OpaqueString[StructName]
+
 enum Def:
   case Enum(
       var values: ListBuffer[(String, Long)],
@@ -123,6 +124,7 @@ enum CType:
   case Struct(fields: List[CType])
   case Union(fields: List[CType])
   case Function(returnType: CType, parameters: List[CType.Parameter])
+  case IncompleteArray(of: CType)
 
   case Void
   case Bool

--- a/bindgen/src/main/scala/analysis/constructType.scala
+++ b/bindgen/src/main/scala/analysis/constructType.scala
@@ -100,6 +100,10 @@ def constructType(typ: CXType)(using
     case CXType_Double     => CType.NumericReal(FloatingBase.Double)
     case CXType_LongDouble => CType.NumericReal(FloatingBase.LongDouble)
 
+    case CXType_IncompleteArray =>
+      val elementType = constructType(clang_getArrayElementType(typ))
+      CType.IncompleteArray(elementType)
+
     case other => warning(s"Unknown type: $spelling"); CType.Void;
   end match
 

--- a/bindgen/src/main/scala/render/hack_recursive_structs.scala
+++ b/bindgen/src/main/scala/render/hack_recursive_structs.scala
@@ -17,13 +17,6 @@ def isCyclical(typ: CType, structName: StructName)(using
             visited ++ List(name),
             level + 1
           )
-      // case Pointer(Reference(Name.Model(name))) =>
-      //   Option.when(visited.contains(name))(visited ++ List(name)) orElse
-      //     go(
-      //       aliasResolver(name),
-      //       visited ++ List(name),
-      //       level + 1
-      //     )
 
       case Struct(fields) =>
         if fields.size > 22 then

--- a/bindgen/src/main/scala/render/hack_recursive_structs.scala
+++ b/bindgen/src/main/scala/render/hack_recursive_structs.scala
@@ -17,13 +17,13 @@ def isCyclical(typ: CType, structName: StructName)(using
             visited ++ List(name),
             level + 1
           )
-      case Pointer(Reference(Name.Model(name))) =>
-        Option.when(visited.contains(name))(visited ++ List(name)) orElse
-          go(
-            aliasResolver(name),
-            visited ++ List(name),
-            level + 1
-          )
+      // case Pointer(Reference(Name.Model(name))) =>
+      //   Option.when(visited.contains(name))(visited ++ List(name)) orElse
+      //     go(
+      //       aliasResolver(name),
+      //       visited ++ List(name),
+      //       level + 1
+      //     )
 
       case Struct(fields) =>
         if fields.size > 22 then
@@ -38,6 +38,8 @@ def isCyclical(typ: CType, structName: StructName)(using
           case (acc, field) =>
             acc orElse go(field, visited, level + 1)
         }
+      case Pointer(to) =>
+        go(to, visited, level + 1)
 
       case _ => Option.empty
     end match
@@ -82,15 +84,6 @@ def hack_recursive_structs(
       )
 
       originalType match
-        case Pointer(Reference(Name.Model(name))) =>
-          Some(
-            ParameterRewrite(
-              name = parameterName,
-              originalType = originalType,
-              newRawType = Pointer(Void),
-              newRichType = Pointer(Reference(Name.Model(name)))
-            )
-          )
         case a @ Pointer(func @ Function(retType, params)) =>
           def rewriteFunctionType(func: Function): Function =
             func.copy(
@@ -126,6 +119,16 @@ def hack_recursive_structs(
               originalType = a,
               newRawType = rewriteFunctionType(func),
               newRichType = a
+            )
+          )
+
+        case Pointer(to) =>
+          Some(
+            ParameterRewrite(
+              name = parameterName,
+              originalType = originalType,
+              newRawType = Pointer(Void),
+              newRichType = Pointer(to)
             )
           )
 

--- a/bindgen/src/main/scala/render/scalaType.scala
+++ b/bindgen/src/main/scala/render/scalaType.scala
@@ -59,6 +59,8 @@ def scalaType(typ: CType)(using AliasResolver): String =
         case Some(cnt) => s"CArray[${scalaType(of)}, ${natDigits(cnt)}]"
         case None      => s"Ptr[${scalaType(of)}]"
 
+    case IncompleteArray(of) => s"Ptr[${scalaType(of)}]"
+
     case Void =>
       "Unit"
     case Bool => "Boolean"

--- a/bindgen/src/main/scala/render/sizes_and_alignments.scala
+++ b/bindgen/src/main/scala/render/sizes_and_alignments.scala
@@ -45,6 +45,7 @@ def alignment(typ: CType)(using AliasResolver): CSize =
     case Bool                          => 1.toULong
     case Reference(Name.Model(name))   => alignment(aliasResolver(name))
     case Reference(Name.BuiltIn(name)) => name.alignment
+    case IncompleteArray(_)            => 1.toULong
     case Union(fields) =>
       1.toULong // TODO: are unions aligned at all?
   end match

--- a/bindgen/src/test/resources/scala-native/flexible_array_member.h
+++ b/bindgen/src/test/resources/scala-native/flexible_array_member.h
@@ -1,0 +1,4 @@
+typedef struct FAM {
+  int len;
+  char data[]; 
+} FAM;

--- a/bindgen/src/test/resources/scala-native/recursive_structs.h
+++ b/bindgen/src/test/resources/scala-native/recursive_structs.h
@@ -32,5 +32,10 @@ typedef struct {
 
 typedef struct {
   double d;
-  struct Ptr_Recrusive_Func **elements;
-} Ptr_Recrusive_Func;
+  struct Ptr_Recursive **elements;
+} Ptr_Recursive;
+
+typedef struct {
+  double d;
+  struct Ptr_Recursive2 ***elements;
+} Ptr_Recursive2;

--- a/bindgen/src/test/resources/scala-native/recursive_structs.h
+++ b/bindgen/src/test/resources/scala-native/recursive_structs.h
@@ -29,3 +29,8 @@ typedef struct {
   void (*free)(struct Recursive_Func *entry);
   int freed;
 } Recursive_Func;
+
+typedef struct {
+  double d;
+  struct Ptr_Recrusive_Func **elements;
+} Ptr_Recrusive_Func;

--- a/bindgen/src/test/scala/TestRecursiveStructs.scala
+++ b/bindgen/src/test/scala/TestRecursiveStructs.scala
@@ -40,6 +40,18 @@ class TestRecursiveStructs:
 
     }
 
+  @Test def test_ptr_recursive: Unit =
+    zone {
+
+      val structPtr = Ptr_Recursive(25.0, null)
+      val struct = !structPtr
+      struct.elements = stackalloc[Ptr[Ptr_Recursive]](1)
+      struct.elements(0) = structPtr
+
+      assertEquals(structPtr, struct.elements(0))
+
+    }
+
   @Test def test_recursive_function_pointer(): Unit =
     zone {
       val struct1 = Recursive_Func(0.5, (_: Ptr[Recursive_Func]) => (), 0)


### PR DESCRIPTION
References #62 

- Ignore FAM members. At this point I'm not sure how to fix it, so we'll just ignore those, because they don't affect static sizes and it's mostly runtime behaviour. And you can hack around it, I think.
- Also fix recursive structs when they're referenced as `Ptr[Ptr[...Struct]]`