### PR TITLE
Introduce a future memory leak

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -568,3 +568,5 @@ inThisBuild(
     )
   )
 )
+
+ThisBuild / version := sys.env.getOrElse("VERSION_OVERRIDE", version.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.1
+sbt.version=1.7.0-M2


### PR DESCRIPTION
It seems unlikely, but there's a lot of wacky memory stuff going on,
and the only possible explanation is that the memory is overwritten by
the GC.

We attempt to fix it by managing the memory manually, so that neither
the GC nor the Zone can see it. Let's see how soon it turns into a
complete disaster

See #57 