### PR TITLE
More memory shenanigans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SN_RELEASE: fast
-      # SN_GC: none
     steps:
       # This step is important to make sure scalafmt 
       # checks don't fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SN_RELEASE: fast
-      SN_GC: none
+      # SN_GC: none
     steps:
       # This step is important to make sure scalafmt 
       # checks don't fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       SN_RELEASE: fast
+      SN_GC: none
     steps:
       # This step is important to make sure scalafmt 
       # checks don't fail

--- a/bindgen/src/main/scala/analysis/analyse.scala
+++ b/bindgen/src/main/scala/analysis/analyse.scala
@@ -43,8 +43,8 @@ def analyse(file: String)(using Zone)(using config: Config): Binding =
         given Config = conf
 
         zone {
-
           val loc = cursor.location
+
           val shouldBeIncluded =
             (loc.isFromMainFile || !loc.isFromSystemHeader) && (
               cursor.spelling != "__gnuc_va_list"

--- a/bindgen/src/main/scala/analysis/capture.scala
+++ b/bindgen/src/main/scala/analysis/capture.scala
@@ -16,7 +16,12 @@ object Captured:
     val rawptr = libc.malloc(sizeof[Captured[D]])
     val mem = fromRawPtr[Captured[D]](rawptr)
     val deallocate: Memory =
-      (value.toString(), () => libc.free(toRawPtr[Captured[D]](mem)))
+      (
+        value.toString(),
+        () =>
+          references.remove(value.asInstanceOf[Object])
+          libc.free(toRawPtr[Captured[D]](mem))
+      )
 
     val tuple = (value, c)
 
@@ -24,6 +29,10 @@ object Captured:
 
     Intrinsics.storeObject(rawptr, tuple)
 
+    references += value.asInstanceOf[Object]
+
     (mem, deallocate)
   end unsafe
+
+  private val references = collection.mutable.Set.empty[Object]
 end Captured

--- a/bindgen/src/main/scala/analysis/capture.scala
+++ b/bindgen/src/main/scala/analysis/capture.scala
@@ -2,18 +2,26 @@ package bindgen
 
 import scala.scalanative.unsafe.*
 
-opaque type Memory = () => Unit
+opaque type Memory = (String, () => Unit)
 object Memory:
-  extension (f: Memory) def deallocate() = f()
+  extension (f: Memory)
+    def deallocate() =
+      System.err.println(s"Deallocating ${f._1}")
+      f._2()
 
 type Captured[D] = (D, Config)
 object Captured:
   def unsafe[D: Tag](value: D)(using c: Config): (Ptr[Captured[D]], Memory) =
     import scalanative.runtime.*
+
+    System.err.println(s"Allocating ${value.toString}")
+
     val mem = fromRawPtr[Captured[D]](libc.malloc(sizeof[Captured[D]]))
-    val deallocate: Memory = () => libc.free(toRawPtr[Captured[D]](mem))
+    val deallocate: Memory =
+      (value.toString(), () => libc.free(toRawPtr[Captured[D]](mem)))
 
     !mem = (value, c)
 
     (mem, deallocate)
+  end unsafe
 end Captured

--- a/bindgen/src/main/scala/analysis/capture.scala
+++ b/bindgen/src/main/scala/analysis/capture.scala
@@ -15,12 +15,18 @@ object Captured:
     import scalanative.runtime.*
 
     System.err.println(s"Allocating ${value.toString}")
-
-    val mem = fromRawPtr[Captured[D]](libc.malloc(sizeof[Captured[D]]))
+    val rawptr = libc.malloc(sizeof[Captured[D]])
+    val mem = fromRawPtr[Captured[D]](rawptr)
     val deallocate: Memory =
       (value.toString(), () => libc.free(toRawPtr[Captured[D]](mem)))
 
-    !mem = (value, c)
+    val tuple = (value, c)
+
+    val originalAddress = Intrinsics.castObjectToRawPtr(tuple)
+
+    Intrinsics.storeObject(rawptr, tuple)
+
+    // System.err.println(s"Original address: $originalAddress, ptr: $rawptr")
 
     (mem, deallocate)
   end unsafe

--- a/bindgen/src/main/scala/analysis/capture.scala
+++ b/bindgen/src/main/scala/analysis/capture.scala
@@ -6,7 +6,6 @@ opaque type Memory = (String, () => Unit)
 object Memory:
   extension (f: Memory)
     def deallocate() =
-      System.err.println(s"Deallocating ${f._1}")
       f._2()
 
 type Captured[D] = (D, Config)
@@ -14,7 +13,6 @@ object Captured:
   def unsafe[D: Tag](value: D)(using c: Config): (Ptr[Captured[D]], Memory) =
     import scalanative.runtime.*
 
-    System.err.println(s"Allocating ${value.toString}")
     val rawptr = libc.malloc(sizeof[Captured[D]])
     val mem = fromRawPtr[Captured[D]](rawptr)
     val deallocate: Memory =
@@ -25,8 +23,6 @@ object Captured:
     val originalAddress = Intrinsics.castObjectToRawPtr(tuple)
 
     Intrinsics.storeObject(rawptr, tuple)
-
-    // System.err.println(s"Original address: $originalAddress, ptr: $rawptr")
 
     (mem, deallocate)
   end unsafe


### PR DESCRIPTION
See https://github.com/scala-native/scala-native/issues/2621

In short, we do our darndest to keep the reference to the object alive, to stop GC from collecting it.