### PR TITLE
More efficient, global alias resolver

### DIFF
--- a/bindgen/src/main/scala/BuiltinType.scala
+++ b/bindgen/src/main/scala/BuiltinType.scala
@@ -2,6 +2,8 @@ package bindgen
 
 import scala.scalanative.libc.stdio.*
 import scala.scalanative.posix.sys.socket.*
+import scala.scalanative.posix.netdb.*
+import scala.scalanative.posix.netinet.in.*
 import scala.scalanative.posix.time.*
 import scala.scalanative.unsafe.*
 import scala.scalanative.unsigned.*
@@ -53,15 +55,13 @@ object BuiltinType:
       "time_t",
       "scala.scalanative.posix.time.time_t"
     ),
-    apply[sockaddr](
-      "sockaddr",
-      "scala.scalanative.posix.sys.socket.sockaddr"
-    ),
     apply[UByte]("uint8_t", _unsigned("UByte")),
     apply[UShort]("uint16_t", _unsigned("UShort")),
     apply[UInt]("uint32_t", _unsigned("UInt")),
+    apply[ULong]("uint64_t", _unsigned("ULong")),
     apply[CChar]("int8_t", _unsafe("CChar")),
     apply[Short]("int16_t", _scala("Short")),
-    apply[CInt]("int32_t", _unsafe("CInt"))
+    apply[CInt]("int32_t", _unsafe("CInt")),
+    apply[Long]("int64_t", _scala("Long"))
   )
 end BuiltinType

--- a/bindgen/src/main/scala/render/struct.scala
+++ b/bindgen/src/main/scala/render/struct.scala
@@ -20,8 +20,6 @@ def struct(model: Def.Struct, line: Appender)(using
         "See https://github.com/indoorvivants/sn-bindgen/issues/62 for details"
     )
 
-  given AliasResolver = ar.nest(struct)
-
   val rewriteRules = hack_recursive_structs(struct)
   val structName = struct.name
   val structType: CType.Struct = CType.Struct(struct.fields.map(_._2).toList)

--- a/bindgen/src/main/scala/render/union.scala
+++ b/bindgen/src/main/scala/render/union.scala
@@ -6,8 +6,6 @@ import bindgen.*
 def union(model: Def.Union, line: Appender)(using Config)(using
     ar: AliasResolver
 ): Unit =
-  given AliasResolver = ar.nest(model)
-
   val structName = model.name
   val unionType: CType.Union = CType.Union(model.fields.map(_._2).toList)
   val tpe = scalaType(unionType)

--- a/bindgen/src/test/resources/scala-native/aliases.h
+++ b/bindgen/src/test/resources/scala-native/aliases.h
@@ -1,0 +1,14 @@
+typedef struct {
+  union {
+    char *bla;
+    int foo;
+  } help;
+} AliasesRef;
+
+typedef struct {
+  union {
+    long help;
+    char *key;
+  } field1;
+  AliasesRef *field2;
+} Test;


### PR DESCRIPTION
When creating a binding for libuv, I noticed an issue - we expand anonymous unions/structs only for the currently rendered struct/union - but the struct is referencing another struct with anonymous union/struct, then alias resolution fails.

As a solution, we pre-build all the aliases along with anonymous structs and unions.