### PR TITLE
Scope settings to Compile/Test/Zero

### DIFF
--- a/sbt-plugin/src/sbt-test/basic/artifacts/build.sbt
+++ b/sbt-plugin/src/sbt-test/basic/artifacts/build.sbt
@@ -1,4 +1,4 @@
-enablePlugins(BindgenPlugin, ScalaNativePlugin)
+enablePlugins(BindgenPlugin, ScalaNativePlugin, ScalaNativeJUnitPlugin)
 
 import bindgen.interface.Binding
 import java.util.concurrent.atomic.AtomicReference
@@ -8,11 +8,24 @@ scalaVersion := "3.1.1"
 bindgenBindings := {
   Seq(
     Binding(
-      baseDirectory.value / "src" / "main" / "resources" / "scala-native" / "header.h",
-      getPackageName.value.get
+      headerFile =
+        baseDirectory.value / "src" / "main" / "resources" / "scala-native" / "header.h",
+      packageName = getPackageName.value.get
     )
   )
 }
+
+Test / bindgenBindings := {
+  Seq(
+    Binding(
+      headerFile =
+        baseDirectory.value / "src" / "main" / "resources" / "scala-native" / "header.h",
+      packageName = "gentests"
+    )
+  )
+}
+
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v")
 
 val changePackageName = taskKey[Unit]("")
 

--- a/sbt-plugin/src/sbt-test/basic/artifacts/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/basic/artifacts/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin(
   "com.indoorvivants" % "bindgen-sbt-plugin" % sys.props("plugin.version")
 )
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.3-RC2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.5")

--- a/sbt-plugin/src/sbt-test/basic/artifacts/src/test/scala/MyTest.scala
+++ b/sbt-plugin/src/sbt-test/basic/artifacts/src/test/scala/MyTest.scala
@@ -1,0 +1,10 @@
+import org.junit.Assert._
+import org.junit.Test
+
+import gentests.functions.*
+
+class MyTest {
+  @Test def superComplicatedTest(): Unit = {
+    assertTrue(hello(42, 0.05f))
+  }
+}

--- a/sbt-plugin/src/sbt-test/basic/artifacts/test
+++ b/sbt-plugin/src/sbt-test/basic/artifacts/test
@@ -1,6 +1,9 @@
 > run
 $ exists target/scala-3.1.1/resource_managed/main/scala-native/libtest.c 
-
+$ exists target/scala-3.1.1/src_managed/main/libtest.scala
+> test
+$ exists target/scala-3.1.1/resource_managed/test/scala-native/gentests.c
+$ exists target/scala-3.1.1/src_managed/test/gentests.scala
 # > clean
 # -$ exists target/scala-3.1.1/resource_managed/main/scala-native/libtest.c 
 # > run # recover after clean


### PR DESCRIPTION
This opens the door for having different generated bindings
in compile and test scopes

It's a step towards removing any custom logic from sn-bindgen's own
build