### PR TITLE
Fix constant array unions, add new/notify/wait to reserved names

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val Versions = new {
   val pluginTargetSBT = "1.6.1"
   val detective = "0.0.2"
 
-  val Scala3 = "3.2.1"
+  val Scala3 = "3.2.2"
   val Scala212 = "2.12.17"
   val Scala213 = "2.13.10"
   val Scala2 = List(Scala212, Scala213)
@@ -110,6 +110,7 @@ lazy val bindgen = project
   .settings(noTests)
   .settings(Compile / nativeConfig ~= environmentConfiguration)
   .settings(nativeConfig ~= usesLibClang)
+  .settings(nativeConfig ~= (_.withIncrementalCompilation(true)))
   .settings(
     buildInfoPackage := "bindgen",
     buildInfoKeys := Seq[BuildInfoKey](

--- a/modules/bindgen/src/main/scala/analysis/constructType.scala
+++ b/modules/bindgen/src/main/scala/analysis/constructType.scala
@@ -21,7 +21,9 @@ def constructType(typ: CXType)(using
   val typekind = typ.kind
   lazy val spelling =
     s"""
-    Kind: ${clang_getTypeKindSpelling(typekind).string}, full type: ${clang_getTypeSpelling(typ).string}
+    Kind: ${clang_getTypeKindSpelling(
+        typekind
+      ).string}, full type: ${clang_getTypeSpelling(typ).string}
     """.stripMargin.trim
 
   val result = typekind match

--- a/modules/bindgen/src/main/scala/render/hack_recursive_structs.scala
+++ b/modules/bindgen/src/main/scala/render/hack_recursive_structs.scala
@@ -139,7 +139,7 @@ def hack_recursive_structs(
 
   if !isPointerRecursive then Map.empty
   else
-    info(s"Struct '$structName' was detected as having cycles")
+    trace(s"Struct '$structName' was detected as having cycles")
 
     struct.fields.zipWithIndex.flatMap { case ((name, typ), idx) =>
       rewrite(name, typ).map { rule =>

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -25,7 +25,8 @@ def sanitise(name: String) =
       "match",
       "true",
       "false",
-      "final"
+      "final",
+      "new"
     )
   if name == "_" then Sanitation.Renamed("$underscore")
   else if keywords.contains(name) || name.endsWith("_") then Sanitation.Escaped
@@ -45,7 +46,8 @@ def escape(name: String) =
       "match",
       "true",
       "false",
-      "final"
+      "final",
+      "new"
     )
   if name == "_" then "$underscore"
   else if keywords.contains(name) || name.endsWith("_") then s"`$name`"

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -26,9 +26,11 @@ def sanitise(name: String) =
       "true",
       "false",
       "final",
-      "new"
+      "new",
     )
+  val reserved = Set("notify", "wait")
   if name == "_" then Sanitation.Renamed("$underscore")
+  else if reserved(name) then Sanitation.Renamed(s"_$name")
   else if keywords.contains(name) || name.endsWith("_") then Sanitation.Escaped
   else Sanitation.Good
 end sanitise

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -26,7 +26,7 @@ def sanitise(name: String) =
       "true",
       "false",
       "final",
-      "new",
+      "new"
     )
   val reserved = Set("notify", "wait")
   if name == "_" then Sanitation.Renamed("$underscore")

--- a/modules/tests/src/test/resources/scala-native/scala_keywords.h
+++ b/modules/tests/src/test/resources/scala-native/scala_keywords.h
@@ -1,1 +1,11 @@
 int test_keywords(int def, int class, int final, int object);
+typedef union test_keywords {
+  char object;
+  long final;
+  void* class;
+  int* def;
+  int val;
+  int var;
+  int new;
+} UnionKeywords;
+

--- a/modules/tests/src/test/resources/scala-native/scala_keywords.h
+++ b/modules/tests/src/test/resources/scala-native/scala_keywords.h
@@ -2,10 +2,23 @@ int test_keywords(int def, int class, int final, int object);
 typedef union test_keywords {
   char object;
   long final;
-  void* class;
-  int* def;
+  void *class;
+  int *def;
   int val;
   int var;
   int new;
+  int notify;
+  int wait;
 } UnionKeywords;
 
+typedef struct test_keywords_struct {
+  char object;
+  long final;
+  void *class;
+  int *def;
+  int val;
+  int var;
+  int new;
+  int notify;
+  int wait;
+} StructKeywords;

--- a/modules/tests/src/test/resources/scala-native/unions.h
+++ b/modules/tests/src/test/resources/scala-native/unions.h
@@ -11,9 +11,15 @@ typedef union UnionOverlapping {
 
 typedef union empty_union UnionEmpty;
 
-typedef union test_keywords {
-  char object;
-  long final;
-  void* class;
-  int* def;
-} UnionKeywords;
+
+typedef struct struct_with_union_array {
+  int g_type;
+  union {
+    long test;
+    char* help;
+  } yo;
+  union {
+    long test;
+    char* help;
+  } data[2];
+} StructWithUnionArray;

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.8.2


### PR DESCRIPTION
Closes #153 and #146

This successfully generates the glib and libnotify binding: https://gist.github.com/keynmol/f33ede98ecb87d4409a8dbc482bdf17c (**2.6MB**)

Unfortunately, the compilation now crashes:

```
Error while emitting t/types$GFileIface$
java.lang.IllegalArgumentException: UTF8 string too large while running genBCode on /Users/velvetbaldmime/projects/sn-bindgen/libnotify.scala
exception occurred while compiling /Users/velvetbaldmime/projects/sn-bindgen/libnotify.scala
java.lang.IllegalArgumentException: UTF8 string too large while compiling /Users/velvetbaldmime/projects/sn-bindgen/libnotify.scala
Exception in thread "main" java.lang.IllegalArgumentException: UTF8 string too large
        at scala.tools.asm.ByteVector.putUTF8(ByteVector.java:255)
        at scala.tools.asm.SymbolTable.addConstantUtf8(SymbolTable.java:774)
        at scala.tools.asm.MethodWriter.<init>(MethodWriter.java:603)
        at scala.tools.asm.ClassWriter.visitMethod(ClassWriter.java:468)
        at scala.tools.asm.tree.MethodNode.accept(MethodNode.java:645)
        at scala.tools.asm.tree.ClassNode.accept(ClassNode.java:451)
        at dotty.tools.backend.jvm.GenBCodePipeline$Worker2.getByteArray$1(GenBCode.scala:516)
        at dotty.tools.backend.jvm.GenBCodePipeline$Worker2.addToQ3(GenBCode.scala:523)
        at dotty.tools.backend.jvm.GenBCodePipeline$Worker2.run(GenBCode.scala:500)
        at dotty.tools.backend.jvm.GenBCodePipeline.buildAndSendToDisk(GenBCode.scala:601)
        at dotty.tools.backend.jvm.GenBCodePipeline.run(GenBCode.scala:564)
        at dotty.tools.backend.jvm.GenBCode.run(GenBCode.scala:69)
```

Or rather, bytecode emitter crashes. This is a known issue I reported before with Nuklear bindings: https://github.com/lampepfl/dotty/issues/15850