### PR TITLE
CLI/Interface option to request no constructors for certain structs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -107,7 +107,6 @@ lazy val bindgen = project
   .dependsOn(libclang)
   .enablePlugins(ScalaNativePlugin, ScalaNativeJUnitPlugin, BuildInfoPlugin)
   .settings(nativeCommon)
-  .settings(noTests)
   .settings(Compile / nativeConfig ~= environmentConfiguration)
   .settings(nativeConfig ~= usesLibClang)
   .settings(nativeConfig ~= (_.withIncrementalCompilation(true)))

--- a/docs/src/main/scala/BindgenRender.scala
+++ b/docs/src/main/scala/BindgenRender.scala
@@ -36,13 +36,34 @@ object BindgenRender:
   def render(
       cSource: String,
       packageName: String,
-      filename: Option[String] = None
-  ) =
+      extra: String*
+  ): String = render(cSource, packageName, None, extra*)
+
+  def render(
+      cSource: String,
+      packageName: String,
+      filename: Option[String],
+      extra: String*
+  ): String =
     val p = os.temp.apply(cSource, deleteOnExit = false, suffix = "header.h")
     val cmd =
-      Seq(binary, "--package", packageName, "--header", p.toString, "--scala")
+      Seq(
+        binary,
+        "--package",
+        packageName,
+        "--header",
+        p.toString,
+        "--scala"
+      ) ++ extra
     val cmdC =
-      Seq(binary, "--package", packageName, "--header", p.toString, "--c")
+      Seq(
+        binary,
+        "--package",
+        packageName,
+        "--header",
+        p.toString,
+        "--c"
+      ) ++ extra
 
     val generatedScala = StringBuilder()
 
@@ -70,7 +91,7 @@ object BindgenRender:
       generatedC.result.linesIterator.exists(_.trim != "<br>")
 
     sideBySide(
-      filename.getOrElse("C header"),
+      filename.getOrElse("C file"),
       cSource,
       generatedScala.result,
       Option.when(hasC)(generatedC.result)

--- a/modules/bindgen/src/main/scala/Config.scala
+++ b/modules/bindgen/src/main/scala/Config.scala
@@ -1,5 +1,9 @@
 package bindgen
 
+case class RenderingConfig(
+    noConstructor: Set[String]
+)
+
 case class Config(
     packageName: PackageName,
     headerFile: HeaderFile,
@@ -13,7 +17,8 @@ case class Config(
     minLogPriority: MinLogPriority = MinLogPriority(3),
     exclusivePrefix: List[ExclusivePrefix] = Nil,
     outputFile: Option[OutputFile],
-    systemPathDetection: SystemPathDetection
+    systemPathDetection: SystemPathDetection,
+    rendering: RenderingConfig
 )
 
 enum SystemPathDetection:

--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -60,6 +60,7 @@ object CLI:
 
   private val isScala =
     Opts.flag("scala", help = "Generate Scala part of the binding").orFalse
+
   private val isC =
     Opts.flag("c", help = "Generate C part of the binding").orFalse
 
@@ -166,6 +167,19 @@ object CLI:
       .orElse(noSystemHeaders)
       .withDefault(SystemPathDetection.Auto)
 
+  private val renderingConfig =
+    val noConstructor = Opts
+      .option[String](
+        "render.no-constructor",
+        help = "Comma-separated list of names of structs, for which to NOT render the constructor\n" + "(apply method that takes all the parameters), useful when \n" + "you see a 'UTF8 string too large while running genBCode'\n" +
+          "example: --render.no-constructor _GFileOutputStreamClass,_GFileIface"
+      )
+      .map(_.split(",").toSet)
+      .withDefault(Set.empty[String])
+
+    noConstructor.map(nc => RenderingConfig(noConstructor = nc))
+  end renderingConfig
+
   val command = Command(
     name = s"bindgen",
     header = "Generate Scala 3 native bindings from C header files" +
@@ -184,7 +198,8 @@ object CLI:
       minLogPriority,
       exclusivePrefix,
       outputFile,
-      systemPathsDetection
+      systemPathsDetection,
+      renderingConfig
     ).mapN(Config.apply)
   }
 end CLI

--- a/modules/bindgen/src/main/scala/main.scala
+++ b/modules/bindgen/src/main/scala/main.scala
@@ -24,8 +24,11 @@ object Generate:
     zone {
       CLI.command.parse(args) match
         case Left(help) =>
-          System.err.println(help)
-          sys.exit(1)
+          val (modified, code) =
+            if help.errors.nonEmpty then help.copy(body = Nil) -> -1
+            else help -> 0
+          System.err.println(modified)
+          sys.exit(code)
         case Right(config) =>
           validateConfig(config) match
             case None =>

--- a/modules/bindgen/src/main/scala/render/struct.scala
+++ b/modules/bindgen/src/main/scala/render/struct.scala
@@ -83,18 +83,24 @@ def struct(model: Def.Struct, line: Appender)(using
         applyArgList.addOne(s"${getter(name.value)} : ${scalaType(inputType)}")
       }
 
-      line(
-        s"def apply(${applyArgList.result.mkString(", ")})(using Zone): Ptr[$structName] = "
-      )
-      nest {
-        line(s"val ____ptr = apply()")
-        struct.fields.foreach { case (fieldName, _) =>
-          line(
-            s"(!____ptr).${getter(fieldName.value)} = ${getter(fieldName.value)}"
-          )
+      if !c.rendering.noConstructor.contains(structName.value) then
+        line(
+          s"def apply(${applyArgList.result.mkString(", ")})(using Zone): Ptr[$structName] = "
+        )
+        nest {
+          line(s"val ____ptr = apply()")
+          struct.fields.foreach { case (fieldName, _) =>
+            line(
+              s"(!____ptr).${getter(fieldName.value)} = ${getter(fieldName.value)}"
+            )
+          }
+          line(s"____ptr")
         }
-        line(s"____ptr")
-      }
+      else
+        warning(
+          s"Not rendering the constructor for ${structName.value}, as requested"
+        )
+      end if
 
       line(s"extension (struct: $structName)")
       nest {

--- a/modules/bindgen/src/test/scala/TestCLI.scala
+++ b/modules/bindgen/src/test/scala/TestCLI.scala
@@ -1,0 +1,49 @@
+package bindgen
+
+import org.junit.Assert.*
+import org.junit.Test
+
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
+
+class TestCLI:
+
+  def parse(cmd: String*) = bindgen.CLI.command.parse(cmd)
+  def parseRight(cmd: Seq[String]) = bindgen.CLI.command
+    .parse(cmd)
+    .fold(h => throw new RuntimeException(h.errors.mkString(", ")), identity)
+
+  def parseExtra(cmd: String*) = parseRight(MINIMUM ++ cmd)
+
+  val MINIMUM = Seq("--package", "helloworld", "--header", "test.h")
+
+  @Test def test_minimum() =
+    assertEquals("helloworld", parseRight(MINIMUM).packageName.value)
+    assertEquals("test.h", parseRight(MINIMUM).headerFile.value)
+
+  @Test def `test_render.no-constructor`() =
+    assertEquals(
+      Set("StructA", "StructB"),
+      parseExtra(
+        "--render.no-constructor",
+        "StructA,StructB"
+      ).rendering.noConstructor
+    )
+
+  @Test def test_langs() =
+    assertEquals(Lang.Scala, parseExtra("--scala").lang)
+    assertEquals(Lang.C, parseExtra("--c").lang)
+
+  @Test def test_out() =
+    assertEquals(
+      Some("test.scala"),
+      parseExtra("--out", "test.scala").outputFile.map(_.value)
+    )
+
+  @Test def test_linkName() =
+    assertEquals(
+      Some("mylib"),
+      parseExtra("--link-name", "mylib").linkName.map(_.value)
+    )
+
+end TestCLI

--- a/modules/interface/src/main/scala/Interface.scala
+++ b/modules/interface/src/main/scala/Interface.scala
@@ -108,7 +108,7 @@ case class Binding private (
     exclusivePrefixes.foreach { prefix =>
       arg("exclusive-prefix", prefix)
     }
-    if(noConstructor.nonEmpty)
+    if (noConstructor.nonEmpty)
       args("--rendering.no-constructor", noConstructor.toList.sorted*)
 
     flag(logLevel.str)

--- a/modules/interface/src/main/scala/Interface.scala
+++ b/modules/interface/src/main/scala/Interface.scala
@@ -83,11 +83,6 @@ case class Binding private (
     def arg(name: String, value: String) =
       sb ++= Seq(s"--$name", value)
 
-    def args(name: String, values: String*) = {
-      sb ++= Seq(s"--$name")
-      sb ++= values
-    }
-
     def flag(name: String) =
       sb += s"--$name"
 
@@ -108,8 +103,9 @@ case class Binding private (
     exclusivePrefixes.foreach { prefix =>
       arg("exclusive-prefix", prefix)
     }
+
     if (noConstructor.nonEmpty)
-      args("--rendering.no-constructor", noConstructor.toList.sorted*)
+      arg("render.no-constructor", noConstructor.toList.sorted.mkString(","))
 
     flag(logLevel.str)
     if (lang == BindingLang.Scala)

--- a/modules/interface/src/main/scala/Interface.scala
+++ b/modules/interface/src/main/scala/Interface.scala
@@ -74,13 +74,19 @@ case class Binding private (
     clangFlags: List[String],
     exclusivePrefixes: List[String],
     logLevel: LogLevel,
-    systemIncludes: Includes
+    systemIncludes: Includes,
+    noConstructor: Set[String]
 ) {
   def toCommand(lang: BindingLang): List[String] = {
     val sb = List.newBuilder[String]
 
     def arg(name: String, value: String) =
       sb ++= Seq(s"--$name", value)
+
+    def args(name: String, values: String*) = {
+      sb ++= Seq(s"--$name")
+      sb ++= values
+    }
 
     def flag(name: String) =
       sb += s"--$name"
@@ -102,6 +108,9 @@ case class Binding private (
     exclusivePrefixes.foreach { prefix =>
       arg("exclusive-prefix", prefix)
     }
+
+    args("--rendering.no-constructor", noConstructor.toList.sorted*)
+
     flag(logLevel.str)
     if (lang == BindingLang.Scala)
       flag("scala")
@@ -122,7 +131,8 @@ object Binding {
       clangFlags: List[String] = Nil,
       exclusivePrefixes: List[String] = Nil,
       logLevel: LogLevel = LogLevel.Info,
-      systemIncludes: Includes = Includes.ClangSearchPath
+      systemIncludes: Includes = Includes.ClangSearchPath,
+      noConstructor: Set[String] = Set.empty
   ) = {
     new Binding(
       headerFile = headerFile,
@@ -134,7 +144,8 @@ object Binding {
       clangFlags = clangFlags,
       exclusivePrefixes = exclusivePrefixes,
       logLevel = logLevel,
-      systemIncludes = systemIncludes
+      systemIncludes = systemIncludes,
+      noConstructor = noConstructor
     )
   }
 }

--- a/modules/interface/src/main/scala/Interface.scala
+++ b/modules/interface/src/main/scala/Interface.scala
@@ -108,8 +108,8 @@ case class Binding private (
     exclusivePrefixes.foreach { prefix =>
       arg("exclusive-prefix", prefix)
     }
-
-    args("--rendering.no-constructor", noConstructor.toList.sorted*)
+    if(noConstructor.nonEmpty)
+      args("--rendering.no-constructor", noConstructor.toList.sorted*)
 
     flag(logLevel.str)
     if (lang == BindingLang.Scala)


### PR DESCRIPTION
Some structs have humongous apply methods which fail to compile because the emitted UTF-8 string with method description is too large:

```
java.lang.IllegalArgumentException: UTF8 string too large while compiling /Users/velvetbaldmime/projects/sn-bindgen/libnotify.scala Exception in thread "main" java.lang.IllegalArgumentException: UTF8 string too large
        at scala.tools.asm.ByteVector.putUTF8(ByteVector.java:255)
        at scala.tools.asm.SymbolTable.addConstantUtf8(SymbolTable.java:774)
        at scala.tools.asm.MethodWriter.<init>(MethodWriter.java:603)
```

There isn't much we can do at this point, so we just allow the user to control the rendering of this particular method.