### PR TITLE
Render comments and collect location

### DIFF
--- a/modules/bindgen/src/main/scala/Config.scala
+++ b/modules/bindgen/src/main/scala/Config.scala
@@ -36,6 +36,12 @@ enum SystemPathDetection:
 opaque type PrintFiles = Boolean
 object PrintFiles extends YesNo[PrintFiles]
 
+opaque type RenderComments = Boolean
+object RenderComments extends YesNo[RenderComments]
+
+opaque type RenderLocation = Boolean
+object RenderLocation extends YesNo[RenderLocation]
+
 opaque type Quiet = Boolean
 object Quiet extends YesNo[Quiet]
 

--- a/modules/bindgen/src/main/scala/Def.scala
+++ b/modules/bindgen/src/main/scala/Def.scala
@@ -66,14 +66,14 @@ enum Def:
       numArguments: Int,
       meta: Meta
   )
-  case Alias(name: String, underlying: CType)
+  case Alias(name: String, underlying: CType, meta: Option[Meta])
 
   def defName: Option[DefName] =
     this match
-      case Alias(name, _) => Some(DefName(name, DefTag.Alias))
-      case u: Union       => Some(DefName(u.name.value, DefTag.Union))
-      case f: Function    => Some(DefName(f.name.value, DefTag.Function))
-      case s: Struct      => Some(DefName(s.name.value, DefTag.Struct))
+      case Alias(name, _, _) => Some(DefName(name, DefTag.Alias))
+      case u: Union          => Some(DefName(u.name.value, DefTag.Union))
+      case f: Function       => Some(DefName(f.name.value, DefTag.Function))
+      case s: Struct         => Some(DefName(s.name.value, DefTag.Struct))
       case e: Enum =>
         e.name.map(enumName => DefName(enumName.value, DefTag.Enum))
 end Def

--- a/modules/bindgen/src/main/scala/Def.scala
+++ b/modules/bindgen/src/main/scala/Def.scala
@@ -31,28 +31,40 @@ object EnumName extends OpaqueString[EnumName]
 opaque type StructName = String
 object StructName extends OpaqueString[StructName]
 
+opaque type CommentText = String
+object CommentText extends OpaqueString[CommentText]
+
+opaque type DefinitionFile = String
+object DefinitionFile extends OpaqueString[DefinitionFile]
+
+case class Meta(comment: Option[CommentText], file: Option[DefinitionFile])
+
 enum Def:
   case Enum(
       values: List[(String, Long)],
       name: Option[EnumName],
-      intType: Option[CType.NumericIntegral]
+      intType: Option[CType.NumericIntegral],
+      meta: Meta
   )
   case Struct(
       fields: List[(StructParameterName, CType)],
       name: StructName,
-      anonymous: List[Def.Union | Def.Struct]
+      anonymous: List[Def.Union | Def.Struct],
+      meta: Meta
   )
   case Union(
       fields: List[(UnionParameterName, CType)],
       name: UnionName,
-      anonymous: List[Def.Union | Def.Struct]
+      anonymous: List[Def.Union | Def.Struct],
+      meta: Meta
   )
   case Function(
       name: FunctionName,
       returnType: CType,
       parameters: List[FunctionParameter],
       originalCType: OriginalCType,
-      numArguments: Int
+      numArguments: Int,
+      meta: Meta
   )
   case Alias(name: String, underlying: CType)
 

--- a/modules/bindgen/src/main/scala/DefBuilder.scala
+++ b/modules/bindgen/src/main/scala/DefBuilder.scala
@@ -13,10 +13,11 @@ sealed trait DefBuilder[Builds]:
   import DefBuilder.*
   def build: Builds =
     this match
-      case e: Enum => Def.Enum(e.values.result(), e.name, e.intType)
+      case e: Enum => Def.Enum(e.values.result(), e.name, e.intType, e.meta)
       case e: Struct =>
-        Def.Struct(e.fields.result(), e.name, e.anonymous.result())
-      case e: Union => Def.Union(e.fields.result, e.name, e.anonymous.result())
+        Def.Struct(e.fields.result(), e.name, e.anonymous.result(), e.meta)
+      case e: Union =>
+        Def.Union(e.fields.result, e.name, e.anonymous.result(), e.meta)
       case e: Function =>
         import e.*
         Def.Function(
@@ -24,7 +25,8 @@ sealed trait DefBuilder[Builds]:
           returnType,
           parameters.result(),
           originalCType,
-          numArguments
+          numArguments,
+          meta
         )
 end DefBuilder
 
@@ -32,19 +34,22 @@ object DefBuilder:
   case class Enum(
       var values: ListBuffer[(String, Long)],
       var name: Option[EnumName],
-      var intType: Option[CType.NumericIntegral]
+      var intType: Option[CType.NumericIntegral],
+      var meta: Meta
   ) extends DefBuilder[Def.Enum]
 
   case class Struct(
       var fields: ListBuffer[(StructParameterName, CType)],
       var name: StructName,
-      var anonymous: ListBuffer[Def.Union | Def.Struct]
+      var anonymous: ListBuffer[Def.Union | Def.Struct],
+      var meta: Meta
   ) extends DefBuilder[Def.Struct]
 
   case class Union(
       var fields: ListBuffer[(UnionParameterName, CType)],
       var name: UnionName,
-      var anonymous: ListBuffer[Def.Union | Def.Struct]
+      var anonymous: ListBuffer[Def.Union | Def.Struct],
+      var meta: Meta
   ) extends DefBuilder[Def.Union]
 
   case class Function(
@@ -52,7 +57,8 @@ object DefBuilder:
       var returnType: CType,
       var parameters: ListBuffer[FunctionParameter],
       val originalCType: OriginalCType,
-      var numArguments: Int
+      var numArguments: Int,
+      var meta: Meta
   ) extends DefBuilder[Def.Function]
 
   case class Alias(name: String, underlying: CType)

--- a/modules/bindgen/src/main/scala/RenderingConfig.scala
+++ b/modules/bindgen/src/main/scala/RenderingConfig.scala
@@ -30,9 +30,12 @@ import RenderingConfig.NameFilter
 
 case class RenderingConfig(
     noConstructor: Set[NameFilter],
-    opaqueStruct: Set[NameFilter]
+    opaqueStruct: Set[NameFilter],
+    comments: RenderComments,
+    location: RenderLocation
 ):
   def matches(f: this.type => Set[NameFilter])(name: String) = f(this).iterator
     .map(_.matches(name))
     .collectFirst { case a if a.isDefined => a }
     .flatten
+end RenderingConfig

--- a/modules/bindgen/src/main/scala/analysis/analyse.scala
+++ b/modules/bindgen/src/main/scala/analysis/analyse.scala
@@ -242,7 +242,7 @@ def addBuiltInAliases(binding: BindingBuilder)(using
                 CType.Reference(
                   Name.Model(ref)
                 ),
-                None
+                _
               ),
               _
             ) if annoyingBastards(ref) =>

--- a/modules/bindgen/src/main/scala/analysis/extractMetadata.scala
+++ b/modules/bindgen/src/main/scala/analysis/extractMetadata.scala
@@ -1,0 +1,28 @@
+package bindgen
+
+import libclang.structs.CXCursor
+import scala.scalanative.unsafe.*
+import libclang.functions.*
+import libclang.fluent.*
+import libclang.aliases.CXFile
+
+def extractMetadata(cursor: CXCursor)(using Zone) =
+  val file = stackalloc[CXFile]()
+  clang_getSpellingLocation(
+    clang_getCursorLocation(cursor),
+    file,
+    null,
+    null,
+    null
+  )
+
+  Meta(
+    comment = Option(clang_Cursor_getBriefCommentText(cursor))
+      .map(_.string)
+      .filter(_ != null)
+      .map(CommentText(_)),
+    file = Option(clang_getFileName(!file).string)
+      .filter(_ != null)
+      .map(DefinitionFile(_))
+  )
+end extractMetadata

--- a/modules/bindgen/src/main/scala/analysis/visitEnum.scala
+++ b/modules/bindgen/src/main/scala/analysis/visitEnum.scala
@@ -26,7 +26,8 @@ def visitEnum(rootCursor: CXCursor, isTypeDef: Boolean)(using
     DefBuilder.Enum(
       mutable.ListBuffer.empty,
       name = None,
-      intType = intType
+      intType = intType,
+      meta = extractMetadata(rootCursor)
     )
   )
   val typ = clang_getCursorType(rootCursor)

--- a/modules/bindgen/src/main/scala/analysis/visitFunction.scala
+++ b/modules/bindgen/src/main/scala/analysis/visitFunction.scala
@@ -26,7 +26,8 @@ def visitFunction(functionCursor: CXCursor)(using Zone, Config): Def.Function =
         constructType(returnType),
         clang_getTypeSpelling(returnType).string
       ),
-      numArguments = clang_getNumArgTypes(typ)
+      numArguments = clang_getNumArgTypes(typ),
+      meta = extractMetadata(functionCursor)
     )
   )
 

--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -214,9 +214,27 @@ object CLI:
       .map(_.split(",").toSet.map(RenderingConfig.NameFilter(_)))
       .withDefault(Set.empty)
 
-    (noConstructor, opaqueStruct).mapN { case (nc, os) =>
-      RenderingConfig(noConstructor = nc, opaqueStruct = os)
-    }
+    val comments = Opts
+      .flag(
+        "render.no-comments",
+        help = "Don't render the comment strings from the source"
+      )
+      .orFalse
+      .map(!_)
+      .map(RenderComments(_))
+
+    val location = Opts
+      .flag(
+        "render.no-location",
+        help = "Don't render the header location for each symbol"
+      )
+      .orFalse
+      .map(!_)
+      .map(RenderLocation(_))
+
+    (noConstructor, opaqueStruct, comments, location).mapN(
+      RenderingConfig.apply
+    )
   end renderingConfig
 
   val outputMode: Opts[OutputMode] =

--- a/modules/bindgen/src/main/scala/render/alias.scala
+++ b/modules/bindgen/src/main/scala/render/alias.scala
@@ -22,6 +22,7 @@ def alias(model: Def.Alias, line: Appender)(using
     case _                                 => true
 
   val modifier = if isOpaque then "opaque " else ""
+  model.meta.foreach(renderComment(line, _))
   line(s"${modifier}type ${model.name} = ${scalaType(underlyingType)}")
   line(s"object ${sanitiseBeforeColon(model.name)}: ")
   nest {

--- a/modules/bindgen/src/main/scala/render/comment.scala
+++ b/modules/bindgen/src/main/scala/render/comment.scala
@@ -1,0 +1,25 @@
+package bindgen
+package rendering
+
+def renderComment(line: Appender, meta: Meta)(using config: Config) =
+  val shouldRenderComment = config.rendering.comments == RenderComments.Yes
+  val shouldRenderLocation = config.rendering.location == RenderLocation.Yes
+
+  if shouldRenderComment || shouldRenderLocation then
+    if meta.comment.nonEmpty || meta.file.nonEmpty then line("/**")
+
+    if shouldRenderComment then
+      meta.comment.foreach { comment =>
+        val lines = comment.value.linesIterator
+        lines.foreach { l => line(" * " + l) }
+
+      }
+
+    meta.file.foreach { file =>
+      if shouldRenderLocation then
+        if meta.comment.nonEmpty && shouldRenderComment then line("")
+        line(s" * [bindgen] header: $file")
+    }
+    line("*/")
+  end if
+end renderComment

--- a/modules/bindgen/src/main/scala/render/enumeration.scala
+++ b/modules/bindgen/src/main/scala/render/enumeration.scala
@@ -23,10 +23,10 @@ def enumeration(model: Def.Enum, line: Appender)(using
       )
     else
       val extension = numericType.base match
-        case IntegralBase.Int   => "Int"
-        case IntegralBase.Long  => "Long"
-        case IntegralBase.Short => "Short"
-        case IntegralBase.Char  => "Byte"
+        case IntegralBase.Int                          => "Int"
+        case IntegralBase.Long | IntegralBase.LongLong => "Long"
+        case IntegralBase.Short                        => "Short"
+        case IntegralBase.Char                         => "Byte"
       line(
         s"inline def define(inline a: Long): $opaqueType = a.toU$extension"
       )

--- a/modules/bindgen/src/main/scala/render/enumeration.scala
+++ b/modules/bindgen/src/main/scala/render/enumeration.scala
@@ -10,6 +10,8 @@ def enumeration(model: Def.Enum, line: Appender)(using
   val numericType = model.intType.getOrElse(CType.Int)
   val enumSuffix = if numericType.sign == SignType.Unsigned then "U" else ""
   val underlyingTypeRender = scalaType(numericType)
+
+  renderComment(line, model.meta)
   line(s"opaque type $opaqueType = $underlyingTypeRender")
   line(s"object $opaqueType extends CEnum$enumSuffix[$opaqueType]:")
 

--- a/modules/bindgen/src/main/scala/render/function.scala
+++ b/modules/bindgen/src/main/scala/render/function.scala
@@ -21,6 +21,7 @@ def renderFunction(f: GeneratedFunction.ScalaFunction, line: Appender)(using
   val access =
     if f.public then "" else s"private[${summon[Config].packageName.value}] "
 
+  if f.public then f.meta.foreach(renderComment(line, _))
   f.body match
     case ScalaFunctionBody.Extern =>
       line(

--- a/modules/bindgen/src/main/scala/render/functionRewriter.scala
+++ b/modules/bindgen/src/main/scala/render/functionRewriter.scala
@@ -38,7 +38,8 @@ enum GeneratedFunction:
       returnType: CType,
       arguments: List[List[FunctionParameter]],
       body: ScalaFunctionBody,
-      public: Boolean
+      public: Boolean,
+      meta: Option[Meta]
   )
 
   case CFunction(
@@ -84,7 +85,8 @@ private def scalaForwarderFunction(
     returnType,
     List(parameters.result),
     ScalaFunctionBody.Extern,
-    public = false
+    public = false,
+    meta = None
   )
 end scalaForwarderFunction
 
@@ -108,7 +110,8 @@ private def scalaAllocatingFunction(bad: Def.Function)(using
         returnValue = isDirectStructAccess(bad.returnType)
       )
     ),
-    public = true
+    public = true,
+    meta = Some(bad.meta)
   )
 end scalaAllocatingFunction
 
@@ -136,7 +139,8 @@ private def scalaPtrFunctions(bad: Def.Function)(using
           returnValue = returnAsWell
         )
       ),
-      public = true
+      public = true,
+      meta = Some(bad.meta)
     )
   }
 
@@ -164,7 +168,8 @@ private def scalaPtrFunctions(bad: Def.Function)(using
             returnValue = false
           )
         ),
-        public = true
+        public = true,
+        meta = Some(bad.meta)
       )
 
     }
@@ -219,7 +224,8 @@ def functionRewriter(badFunction: Def.Function)(using
         badFunction.returnType,
         List(badFunction.parameters.toList),
         ScalaFunctionBody.Extern,
-        public = true
+        public = true,
+        meta = Some(badFunction.meta)
       )
     )
   end if

--- a/modules/bindgen/src/main/scala/render/struct.scala
+++ b/modules/bindgen/src/main/scala/render/struct.scala
@@ -83,6 +83,8 @@ def struct(model: Def.Struct, line: Appender)(using
         .map(_._2)
         .map(p => p.name.value -> p.newRawType)
     )
+
+  renderComment(line, model.meta)
   line(s"opaque type $structName = ${scalaType(finalStructType)}")
   line(s"object ${sanitiseBeforeColon(structName.value)}:")
   nest {

--- a/modules/bindgen/src/main/scala/render/union.scala
+++ b/modules/bindgen/src/main/scala/render/union.scala
@@ -23,6 +23,7 @@ def union(model: Def.Union, line: Appender)(using Config)(using
       case Renamed(value) => value
       case Escaped        => s"`$name`"
 
+  renderComment(line, model.meta)
   line(s"opaque type $unionName = $tpe")
   line(s"object ${sanitiseBeforeColon(unionName.value)}:")
   nest {

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -97,17 +97,17 @@ object AliasResolver:
     val mapping = Map.newBuilder[String, CType]
     def go(definitions: Seq[Def]): Unit =
       definitions.foreach {
-        case st @ Def.Struct(fields, name, _) =>
+        case st @ Def.Struct(fields, name, _, _) =>
           val typ = CType.Struct(fields.map(_._2).toList)
           mapping += name.value -> typ
           mapping ++= traverse(st)
-        case u @ Def.Union(fields, name, _) =>
+        case u @ Def.Union(fields, name, _, _) =>
           val typ = CType.Struct(fields.map(_._2).toList)
           mapping += name.value -> typ
           mapping ++= traverse(u)
         case Def.Alias(name, underlying) =>
           mapping += name -> underlying
-        case Def.Enum(_, Some(name), Some(tp)) =>
+        case Def.Enum(_, Some(name), Some(tp), _) =>
           mapping += name.value -> tp
         case _ =>
       }

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -105,7 +105,7 @@ object AliasResolver:
           val typ = CType.Struct(fields.map(_._2).toList)
           mapping += name.value -> typ
           mapping ++= traverse(u)
-        case Def.Alias(name, underlying) =>
+        case Def.Alias(name, underlying, _) =>
           mapping += name -> underlying
         case Def.Enum(_, Some(name), Some(tp), _) =>
           mapping += name.value -> tp

--- a/modules/bindgen/src/test/scala/TestCLI.scala
+++ b/modules/bindgen/src/test/scala/TestCLI.scala
@@ -37,6 +37,34 @@ class TestCLI:
     )
   end `test_render.no-constructor`
 
+  @Test def `test_render.no-comments`() =
+    import RenderingConfig.*
+    assertEquals(
+      false,
+      parseExtra(
+        "--render.no-comments"
+      ).rendering.comments.value
+    )
+    assertEquals(
+      true,
+      parseExtra().rendering.comments.value
+    )
+  end `test_render.no-comments`
+
+  @Test def `test_render.no-location`() =
+    import RenderingConfig.*
+    assertEquals(
+      false,
+      parseExtra(
+        "--render.no-location"
+      ).rendering.location.value
+    )
+    assertEquals(
+      true,
+      parseExtra().rendering.location.value
+    )
+  end `test_render.no-location`
+
   @Test def `test_render.opaque-structs`() =
     import RenderingConfig.*
     assertEquals(

--- a/modules/interface/src/main/scala/Interface.scala
+++ b/modules/interface/src/main/scala/Interface.scala
@@ -77,7 +77,9 @@ case class Binding private (
     systemIncludes: Includes,
     noConstructor: Set[String],
     opaqueStructs: Set[String],
-    multiFile: Boolean
+    multiFile: Boolean,
+    noComments: Boolean,
+    noLocation: Boolean
 ) {
   def toCommand(lang: BindingLang): List[String] = {
     val sb = List.newBuilder[String]
@@ -119,6 +121,8 @@ case class Binding private (
       flag("c")
 
     if (multiFile && lang == BindingLang.Scala) flag("multi-file")
+    if (noComments && lang == BindingLang.Scala) flag("render.no-comments")
+    if (noLocation && lang == BindingLang.Scala) flag("render.no-location")
 
     sb.result()
   }
@@ -137,7 +141,9 @@ object Binding {
       systemIncludes: Includes = Includes.ClangSearchPath,
       noConstructor: Set[String] = Set.empty,
       opaqueStructs: Set[String] = Set.empty,
-      multiFile: Boolean = false
+      multiFile: Boolean = false,
+      noComments: Boolean = false,
+      noLocation: Boolean = false
   ) = {
     new Binding(
       headerFile = headerFile,
@@ -152,7 +158,9 @@ object Binding {
       systemIncludes = systemIncludes,
       noConstructor = noConstructor,
       opaqueStructs = opaqueStructs,
-      multiFile = multiFile
+      multiFile = multiFile,
+      noComments = noComments,
+      noLocation = noLocation
     )
   }
 }


### PR DESCRIPTION
I.e. on libclang we now get:

```scala
  /**
   * Visit the children of a particular cursor.

   * [bindgen] header: /opt/homebrew/opt/llvm@14/include/clang-c/Index.h
  */
  def clang_visitChildren(parent : Ptr[CXCursor], visitor : CXCursorVisitor, client_data : CXClientData): CUnsignedInt =
    __sn_wrap_libclang_clang_visitChildren(parent, visitor, client_data)

  /**
   * Visit the children of a particular cursor.

   * [bindgen] header: /opt/homebrew/opt/llvm@14/include/clang-c/Index.h
  */
  def clang_visitChildren(parent : CXCursor, visitor : CXCursorVisitor, client_data : CXClientData)(using Zone): CUnsignedInt =
    val __ptr_0: Ptr[CXCursor] = alloc[CXCursor](1)
    !(__ptr_0 + 0) = parent
    __sn_wrap_libclang_clang_visitChildren((__ptr_0 + 0), visitor, client_data)

  /**
   * Visits the children of a cursor using the specified block. Behaves identically to clang_visitChildren() in all other respects.

   * [bindgen] header: /opt/homebrew/opt/llvm@14/include/clang-c/Index.h
  */
  def clang_visitChildrenWithBlock(parent : CXCursor, block : CXCursorVisitorBlock)(using Zone): CUnsignedInt =
    val __ptr_0: Ptr[CXCursor] = alloc[CXCursor](1)
    !(__ptr_0 + 0) = parent
    __sn_wrap_libclang_clang_visitChildrenWithBlock((__ptr_0 + 0), block)

  /**
   * Visits the children of a cursor using the specified block. Behaves identically to clang_visitChildren() in all other respects.

   * [bindgen] header: /opt/homebrew/opt/llvm@14/include/clang-c/Index.h
  */
  def clang_visitChildrenWithBlock(parent : Ptr[CXCursor], block : CXCursorVisitorBlock): CUnsignedInt =
    __sn_wrap_libclang_clang_visitChildrenWithBlock(parent, block)
```