### PR TITLE
Binding builder interface and render exports in separate files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,8 @@ lazy val iface = projectMatrix
   )
   .settings(
     moduleName := "bindgen-interface",
-    libraryDependencies += "com.indoorvivants.detective" %%% "platform" % Versions.detective
+    libraryDependencies += "com.indoorvivants.detective" %%% "platform" % Versions.detective,
+    scalacOptions += "-deprecation"
   )
   .enablePlugins(BuildInfoPlugin)
   .settings(

--- a/docs/pages/configuration.md
+++ b/docs/pages/configuration.md
@@ -6,6 +6,16 @@ mdoc:true
 
 # SBT plugin 
 
+<!--toc:start-->
+- [SBT plugin](#sbt-plugin)
+  - [`bindgenVersion`: _String_](#bindgenversion-string)
+  - [`bindgenBinary`: _java.io.File_](#bindgenbinary-javaiofile)
+  - [`bindgenMode`: `bindgen.interface.BindgenMode`](#bindgenmode-bindgeninterfacebindgenmode)
+    - [Source/resource generator mode](#sourceresource-generator-mode)
+    - [Manual mode](#manual-mode)
+  - [CLI](#cli)
+<!--toc:end-->
+
 ## `bindgenVersion`: _String_
 
 Use this to choose another version of bindgen (by default it matches the plugin version)
@@ -18,6 +28,31 @@ By default it's resolved from Sonatype for your particular platform.
 ```scala
 bindgenBinary := baseDirectory.value / "my-custom-binary"
 ```
+
+## `bindgenMode`: `bindgen.interface.BindgenMode`
+
+This parameter controls the way the bindgen is invoked and the location where the generated files will be placed
+
+### Source/resource generator mode 
+
+Value `ResourceGenerator`, the **default**.
+
+In this mode the bindings will be regenerated automatically when the project is compiled or run.
+
+The generated files are put in locations that are usually ignored by VCS (under `target`).
+
+### Manual mode 
+
+Value `Manual(scalaDir: File, cDir: File)`.
+
+In this mode you control the location of generated Scala/C files, and you need to manually invoke the generator
+by calling `bindgenGenerateScalaSources` and `bindgenGenerateCSources`.
+
+This mode is useful for bindings you don't intend to modify often, and want to the sources available in checked in 
+code.
+
+For example, the bindings to libclang which underpin this very project are generated using this mode and checked in on Github.
+
 
 ## CLI
 

--- a/modules/bindgen/src/main/scala/render/binding.scala
+++ b/modules/bindgen/src/main/scala/render/binding.scala
@@ -185,7 +185,14 @@ def binding(
     }
   end if
 
-  renderExports(stream("all"), exports.result(), renderMode)
+  if multiFileMode then
+    val byType: Map[String, List[(String, String)]] =
+      exports.result().groupBy(_._1)
+
+    byType.toList.sortBy(_._1).foreach { (exportType, results) =>
+      renderExports(stream(s"all.$exportType"), results, renderMode)
+    }
+  else renderExports(stream(s"all"), exports.result(), renderMode)
 
   if multiFileMode then RenderedOutput.Multi(multi.toMap)
   else if lang == Lang.C then RenderedOutput.Single(cOutput)

--- a/modules/interface/src/main/scala/Interface.scala
+++ b/modules/interface/src/main/scala/Interface.scala
@@ -80,7 +80,6 @@ class Binding private (
     val multiFile: Boolean,
     val noComments: Boolean,
     val noLocation: Boolean,
-    // val renderAll: Boolean,
     val scalaFile: String,
     val cFile: String
 ) { self =>
@@ -99,7 +98,6 @@ class Binding private (
       multiFile: Boolean = self.multiFile,
       noComments: Boolean = self.noComments,
       noLocation: Boolean = self.noLocation,
-      // renderAll: Boolean = self.renderAll,
       scalaFile: String = self.scalaFile,
       cFile: String = self.cFile
   ) =
@@ -117,7 +115,6 @@ class Binding private (
       multiFile = multiFile,
       noComments = noComments,
       noLocation = noLocation,
-      // renderAll = renderAll,
       scalaFile = scalaFile,
       cFile = cFile
     )
@@ -166,7 +163,6 @@ class Binding private (
     if (multiFile && lang == BindingLang.Scala) flag("multi-file")
     if (noComments && lang == BindingLang.Scala) flag("render.no-comments")
     if (noLocation && lang == BindingLang.Scala) flag("render.no-location")
-    // if (!renderAll && lang == BindingLang.Scala) flag("render.no-all")
 
     sb.result()
   }
@@ -190,7 +186,6 @@ object Binding {
         multiFile = Defaults.multiFile,
         noComments = Defaults.noComments,
         noLocation = Defaults.noLocation,
-        // renderAll = Defaults.renderAll,
         cFile = s"$packageName.c",
         scalaFile = s"$packageName.scala"
       )
@@ -233,8 +228,6 @@ object Binding {
     def withOpaqueStructs(structs: Set[String]) = copy(
       _.copy(opaqueStructs = structs)
     )
-
-    // def withRenderAll(b: Boolean) = copy(_.copy(renderAll = b))
 
     def build: Binding = binding
   }

--- a/modules/tests/src/test/scalajvm/TestInterface.scala
+++ b/modules/tests/src/test/scalajvm/TestInterface.scala
@@ -174,12 +174,13 @@ class TestInterface {
   @Test def adds_package_name(): Unit = isolate { probe =>
     val bind =
       Binding(headerFile, "lib_my_awesome_library")
+
     probe.builder
       .generate(Seq(bind), probe.scalaFiles, BindingLang.Scala, plat)
 
     assertEquals(
-      lines(probe.scalaFiles / "lib_my_awesome_library.scala").head,
-      "package lib_my_awesome_library"
+      "package lib_my_awesome_library",
+      lines(probe.scalaFiles / "lib_my_awesome_library.scala").head
     )
   }
 

--- a/modules/tests/src/test/scalajvm/TestInterface.scala
+++ b/modules/tests/src/test/scalajvm/TestInterface.scala
@@ -80,7 +80,10 @@ class TestInterface {
 
   @Test def adds_c_imports(): Unit = isolate { probe =>
     val bind =
-      Binding(headerFile, "lib_check", cImports = List("my_cool_library.h"))
+      Binding
+        .builder(headerFile, "lib_check")
+        .withCImports(List("my_cool_library.h"))
+        .build
 
     probe.builder
       .generate(Seq(bind), probe.cFiles, BindingLang.C, plat)
@@ -98,7 +101,10 @@ class TestInterface {
 
   @Test def adds_link_name(): Unit = isolate { probe =>
     val bind =
-      Binding(headerFile, "lib_check", linkName = Some("my-awesome-library"))
+      Binding
+        .builder(headerFile, "lib_check")
+        .withLinkName("my-awesome-library")
+        .build
 
     probe.builder
       .generate(Seq(bind), probe.scalaFiles, BindingLang.Scala, plat)
@@ -113,12 +119,11 @@ class TestInterface {
 
   @Test def multi_file(): Unit = isolate { probe =>
     val bind =
-      Binding(
-        headerFile,
-        "lib_check",
-        linkName = Some("my-awesome-library"),
-        multiFile = true
-      )
+      Binding
+        .builder(headerFile, "lib_check")
+        .withLinkName("my-awesome-library")
+        .withMultiFile(true)
+        .build
 
     val allFiles = probe.builder
       .generate(Seq(bind), probe.scalaFiles, BindingLang.Scala, plat)
@@ -133,12 +138,11 @@ class TestInterface {
 
   @Test def print_file(): Unit = isolate { probe =>
     def bind(multi: Boolean) =
-      Binding(
-        headerFile,
-        "lib_check",
-        linkName = Some("my-awesome-library"),
-        multiFile = multi
-      )
+      Binding
+        .builder(headerFile, "lib_check")
+        .withLinkName("my-awesome-library")
+        .withMultiFile(multi)
+        .build
 
     val allFilesScala = probe.builder
       .generate(Seq(bind(false)), probe.scalaFiles, BindingLang.Scala, plat)
@@ -198,11 +202,10 @@ class TestInterface {
     }
 
     val binding =
-      Binding(
-        customCFile,
-        "lib_my_awesome_library",
-        opaqueStructs = Set("StructA", "StructB")
-      )
+      Binding
+        .builder(customCFile, "lib_my_awesome_library")
+        .withOpaqueStructs(Set("StructA", "StructB"))
+        .build
 
     probe.builder
       .generate(Seq(binding), probe.scalaFiles, BindingLang.Scala, plat)
@@ -244,11 +247,12 @@ class TestInterface {
     }
 
     val binding =
-      Binding(
-        customCFile,
-        "lib_my_awesome_library",
-        noConstructor = Set("StructA", "StructB")
-      )
+      Binding
+        .builder(customCFile, "lib_my_awesome_library")
+        .withNoConstructor(
+          Set("StructA", "StructB")
+        )
+        .build
 
     probe.builder
       .generate(Seq(binding), probe.scalaFiles, BindingLang.Scala, plat)
@@ -295,11 +299,11 @@ class TestInterface {
     assertTrue(opt.isFailure)
 
     val withFlags =
-      Binding(
-        customCFile,
-        "lib_check",
-        clangFlags = List(s"-I${headerFile.getParentFile()}")
-      )
+      Binding
+        .builder(customCFile, "lib_check")
+        .withClangFlags(List(s"-I${headerFile.getParentFile()}"))
+        .build
+
     // if we add additional `-I` flag with correct location, it should succeed
     val optFixed = Try(
       probe.builder

--- a/modules/tests/src/test/scalajvm/TestInterface.scala
+++ b/modules/tests/src/test/scalajvm/TestInterface.scala
@@ -160,7 +160,11 @@ class TestInterface {
         probe.scalaFiles / "lib_check" / "aliases.scala",
         probe.scalaFiles / "lib_check" / "structs.scala",
         probe.scalaFiles / "lib_check" / "functions.scala",
-        probe.scalaFiles / "lib_check" / "all.scala",
+        probe.scalaFiles / "lib_check" / "all.unions.scala",
+        probe.scalaFiles / "lib_check" / "all.structs.scala",
+        probe.scalaFiles / "lib_check" / "all.functions.scala",
+        probe.scalaFiles / "lib_check" / "all.aliases.scala",
+        probe.scalaFiles / "lib_check" / "all.enumerations.scala",
         probe.scalaFiles / "lib_check" / "unions.scala"
       ),
       allFilesMultiScala.toSet


### PR DESCRIPTION
render all.scala as several individual files to avoid triggering class too big errors.

Also, replace a case class with a builder pattern.