### PR TITLE
Add nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,80 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700686189,
+        "narHash": "sha256-HtewMk7rgXctQjde2o1e8sMgOT04Jp2VQNZUEwpOB+4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "754f40a5ffe658704381e6cb01d7f8fb030e8ac9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "sbt": "sbt",
+        "systems": "systems"
+      }
+    },
+    "sbt": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1698464090,
+        "narHash": "sha256-Pnej7WZIPomYWg8f/CZ65sfW85IfIUjYhphMMg7/LT0=",
+        "owner": "zaninime",
+        "repo": "sbt-derivation",
+        "rev": "6762cf2c31de50efd9ff905cbcc87239995a4ef9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zaninime",
+        "ref": "master",
+        "repo": "sbt-derivation",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "sn-bindgen";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
+  inputs.sbt.url = "github:zaninime/sbt-derivation/master";
+  inputs.sbt.inputs.nixpkgs.follows = "nixpkgs";
+
+  inputs.systems.url = "github:nix-systems/default";
+
+  outputs = {
+    self,
+    nixpkgs,
+    sbt,
+    systems
+  }:
+    let
+      eachSystem = nixpkgs.lib.genAttrs (import systems);
+    in
+    {
+      packages = eachSystem (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          default = sbt.mkSbtDerivation.${system} {
+            pname = "sn-bindgen";
+            version = "0.1.0";
+            src = self;
+            depsSha256 = "sha256-3sgPKN1/0lxSxOtetlWS/NobXIpQ6a7Ygk2GOprYIcg=";
+            buildPhase = ''
+              sbt 'show buildBinary'
+            '';
+            depsWarmupCommand = ''
+              sbt 'update'
+              sbt 'iface/compile ; iface2_12/compile ; iface3/compile'
+              sbt 'ifaceNative/compile ; ifaceNative2_12/compile ; ifaceNative3/compile'
+            '';
+            installPhase = ''
+              mkdir -p $out/bin
+              cp bin/bindgen $out/bin/
+            '';
+            buildInputs = with pkgs; [
+              libclang
+            ];
+            nativeBuildInputs = with pkgs; [
+              clang
+              libunwind
+              stdenv
+              which
+              zlib
+            ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
`nix develop` to get a developer environment. `nix shell` to build `bindgen` and start a shell with `bindgen` in `PATH`. 

The `depsWarmupCommand` is a bit complicated: Has to compile enough but not too much.

To try this branch directly: `nix shell github:coreyoconnor/sn-bindgen/add-nix-flake`.