### PR TITLE
Add Nix overlay to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,5 +61,8 @@
           };
         }
       );
+      overlays.default = final: prev: {
+        sn-bindgen = self.packages.${final.system}.default;
+      };
     };
 }


### PR DESCRIPTION
Makes it easier to add `sn-bindgen` as a package to one's `nixpkgs`:

```nix
let
  pkgs = import nixpkgs {
    inherit system;
    overlays = [
      sbt-derivation.overlays.default
      sn-bindgen.overlays.default
    ];
  };
in pkgs.mkShell { packages = with pkgs; [sn-bindgen]; }
```