### PR TITLE
Don't render `all` package and exports in multi-file mode

### DIFF
--- a/modules/bindgen/src/main/scala/render/TypeImports.scala
+++ b/modules/bindgen/src/main/scala/render/TypeImports.scala
@@ -11,17 +11,16 @@ case class TypeImports(
     structs: Boolean,
     unions: Boolean
 ):
-  def render(out: LineBuilder, multiFile: Boolean)(using Config, Context) =
-    var any = false
-    val imp = (s: String) =>
-      any = true
-      to(out)(s"import _root_.$packageName.$s.*")
+  def render(out: LineBuilder)(using Config, Context) =
+
+    val addImport = (s: String) => to(out)(s"import _root_.$packageName.$s.*")
+
     if enums then
-      imp("enumerations")
-      if !multiFile then imp("predef")
-    if aliases then imp("aliases")
-    if structs then imp("structs")
-    if unions then imp("unions")
+      addImport("enumerations")
+      addImport("predef")
+    if aliases then addImport("aliases")
+    if structs then addImport("structs")
+    if unions then addImport("unions")
 
   end render
 end TypeImports

--- a/modules/bindgen/src/main/scala/render/function.scala
+++ b/modules/bindgen/src/main/scala/render/function.scala
@@ -50,7 +50,7 @@ def renderFunction(
 
     case ScalaFunctionBody.Extern =>
       val linkAnnotation = Option
-        .when(f.public)(
+        .when(f.public && mode == RenderMode.Files)(
           summon[Config].linkName
             .map { l =>
               s"""@link("$l") """

--- a/modules/sbt-plugin/src/sbt-test/basic/multi-file/src/main/scala/run.scala
+++ b/modules/sbt-plugin/src/sbt-test/basic/multi-file/src/main/scala/run.scala
@@ -1,4 +1,4 @@
-import bindings.functions.*
+import bindings.*
 
 @main def test =
   assert(hello(25, 0.5f) == true)

--- a/modules/sbt-plugin/src/sbt-test/basic/multi-file/src/test/scala/MyTest.scala
+++ b/modules/sbt-plugin/src/sbt-test/basic/multi-file/src/test/scala/MyTest.scala
@@ -1,7 +1,7 @@
 import org.junit.Assert.*
 import org.junit.Test
 
-import testbindings.functions.*
+import testbindings.*
 
 class MyTest {
   @Test def superComplicatedTest(): Unit = {

--- a/modules/tests/src/test/resources/scala-native/multi_file.c
+++ b/modules/tests/src/test/resources/scala-native/multi_file.c
@@ -3,3 +3,7 @@
 unsigned run(int i, float h, HelloAlias test, union Test verify) { return 42; };
 void naughty(Hello st){};
 void nice(char st){};
+
+int test_varargs(int i, ...) {
+  return i;
+}

--- a/modules/tests/src/test/resources/scala-native/multi_file.h
+++ b/modules/tests/src/test/resources/scala-native/multi_file.h
@@ -17,3 +17,5 @@ unsigned run(int i, float h, HelloAlias test, union Test verify);
 void naughty(Hello st);
 void nice(char st);
 enum { Constant1, Constant2 };
+
+int test_varargs(int i, ...);

--- a/modules/tests/src/test/scalajvm/TestInterface.scala
+++ b/modules/tests/src/test/scalajvm/TestInterface.scala
@@ -164,11 +164,6 @@ class TestInterface {
         probe.scalaFiles / "lib_check" / "aliases.scala",
         probe.scalaFiles / "lib_check" / "structs.scala",
         probe.scalaFiles / "lib_check" / "functions.scala",
-        probe.scalaFiles / "lib_check" / "all.unions.scala",
-        probe.scalaFiles / "lib_check" / "all.structs.scala",
-        probe.scalaFiles / "lib_check" / "all.functions.scala",
-        probe.scalaFiles / "lib_check" / "all.aliases.scala",
-        probe.scalaFiles / "lib_check" / "all.enumerations.scala",
         probe.scalaFiles / "lib_check" / "unions.scala"
       ),
       allFilesMultiScala.toSet


### PR DESCRIPTION
This is a breaking change, designed to work around a problem I found: https://github.com/scala-native/scala-native/issues/3231#issuecomment-1885336121

All C definitions will be rendered in same package, at top level.

I wonder if this will have any effect on reachability, as we no longer have 1 big ass object (`extern_functions`) holding potentially the entire C API of a library..