### PR TITLE
Update nix deps

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700686189,
-        "narHash": "sha256-HtewMk7rgXctQjde2o1e8sMgOT04Jp2VQNZUEwpOB+4=",
+        "lastModified": 1732322696,
+        "narHash": "sha256-G/3mKjjWyZdns9TQmvg27n4nsfLtAztioW7cO7GMS8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "754f40a5ffe658704381e6cb01d7f8fb030e8ac9",
+        "rev": "80dd5c18b78cac12304774e317f162bae94a1172",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,10 +48,10 @@
               cp bin/bindgen $out/bin/
             '';
             buildInputs = with pkgs; [
-              libclang
+              llvmPackages_17.libclang
             ];
             nativeBuildInputs = with pkgs; [
-              clang
+              clang_17
               libunwind
               stdenv
               which

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
                 ./build.sbt
               ];
             };
-            depsSha256 = "sha256-3sgPKN1/0lxSxOtetlWS/NobXIpQ6a7Ygk2GOprYIcg=";
+            depsSha256 = "sha256-dF5KMFD7CZPonHB4F0dhsz4KuDQr6d0qLxfTELVM6IA";
             buildPhase = ''
               sbt 'show buildBinary'
             '';


### PR DESCRIPTION
It's unfortunate, but the `depsSha256` needs to be updated every time any Scala dependencies change. Don't get me started on why we don't have better Nix integrations in Scala... but this should do for now.

SIKE, it does not do for now:

```
error: builder for '/nix/store/xb7mabgfr435lq7r1awixbmvawmdvy7a-sn-bindgen-0.1.0.drv' failed with exit code 1;
       last 25 log lines:
       > [error] /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c:785:9: error: returning 'int' from a function with incompatible result type 'enum CXUnaryOperatorKind'
       > [error]  return clang_getCursorUnaryOperatorKind(*cursor);
       > [error]         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > [error] /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c:806:22: warning: 'clang_getDiagnosticCategoryName' is deprecated [-Wdeprecated-declarations]
       > [error]   CXString ____ret = clang_getDiagnosticCategoryName(Category);
       > [error]                      ^
       > [error] /nix/store/bfwr9iyk5jmn9bf49p326yi44f3ncpl0-clang-16.0.6-dev/include/clang-c/CXDiagnostic.h:307:1: note: 'clang_getDiagnosticCategoryName' has been explicitly marked deprecated here
       > [error] CINDEX_DEPRECATED CINDEX_LINKAGE CXString
       > [error] ^
       > [error] /nix/store/bfwr9iyk5jmn9bf49p326yi44f3ncpl0-clang-16.0.6-dev/include/clang-c/Platform.h:42:44: note: expanded from macro 'CINDEX_DEPRECATED'
       > [error]   #define CINDEX_DEPRECATED __attribute__((deprecated))
       > [error]                                            ^
       > [error] /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c:1099:85: error: variable has incomplete type 'enum CXUnaryOperatorKind'
       > [error] void __sn_wrap_libclang_clang_getUnaryOperatorKindSpelling(enum CXUnaryOperatorKind kind, CXString *____return) {
       > [error]                                                                                     ^
       > [error] /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c:784:6: note: forward declaration of 'enum CXUnaryOperatorKind'
       > [error] enum CXUnaryOperatorKind __sn_wrap_libclang_clang_getCursorUnaryOperatorKind(CXCursor *cursor) {
       > [error]      ^
       > [error] /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c:1100:22: error: call to undeclared function 'clang_getUnaryOperatorKindSpelling'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
       > [error]   CXString ____ret = clang_getUnaryOperatorKindSpelling(kind);
       > [error]                      ^
       > [error] 2 warnings and 11 errors generated.
       > [error] Failed to compile /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c
       > [error] (bindgen / Compile / nativeLink) Failed to compile /private/tmp/nix-build-sn-bindgen-0.1.0.drv-0/source/modules/bindgen/target/scala-3.3.4/native/native-code-classes-0/scala-native/generated/libclang.c
       > [error] Total time: 29 s, completed Nov 23, 2024, 12:29:57 AM
       For full logs, run 'nix log /nix/store/xb7mabgfr435lq7r1awixbmvawmdvy7a-sn-bindgen-0.1.0.drv'.
```

I have not investigated this yet, just posting for visibility in case any other Nix nerds try to build latest.