### PR TITLE
Add missing space in help message

### DIFF
--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -177,7 +177,7 @@ object CLI:
     .options[String](
       "exclusive-prefix",
       help =
-        "When provided, only definitions that start with this prefix will be" +
+        "When provided, only definitions that start with this prefix will be " +
           "rendered",
       visibility = Visibility.Partial
     )


### PR DESCRIPTION
<img width="928" alt="image" src="https://github.com/user-attachments/assets/761f1a45-92c6-4836-a977-f4e1c3760c3e">
