### PR TITLE
Update dependency hash again, idk why

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
                 ./build.sbt
               ];
             };
-            depsSha256 = "sha256-dF5KMFD7CZPonHB4F0dhsz4KuDQr6d0qLxfTELVM6IA";
+            depsSha256 = "sha256-guxXAKIlTi48ZFQwFyEV6bHPy0islCfQiOMf9slCsYM=";
             buildPhase = ''
               sbt 'show buildBinary'
             '';


### PR DESCRIPTION
I think I just didn't rerun the dependency build after having updated the flake lock, and because it's a fixed-output derivation it didn't even rerun the build of that.