### PR TITLE
Resolve Pointer(Reference(Unnamed)) by mapping to enclosing anonymous

### DIFF
--- a/modules/tests/src/test/resources/scala-native/structs.h
+++ b/modules/tests/src/test/resources/scala-native/structs.h
@@ -78,3 +78,21 @@ typedef struct StructAnonymous {
     char *value;
   } header;
 } StructAnonymous;
+
+typedef struct StructAnonymousPointer {
+  struct {
+      int x;
+      int y;
+  } *pos;
+  struct {
+      int oneField;
+  } *offsets;
+
+  struct {
+      struct {
+          int inner;
+      } nested;
+  } *c;
+
+  int count;
+} StructAnonymousPointer;

--- a/modules/tests/src/test/scalanative/TestStructs.scala
+++ b/modules/tests/src/test/scalanative/TestStructs.scala
@@ -126,4 +126,20 @@ class TestStructs:
       assertEquals("what", fromCString(struct.context.str))
     }
 
+  @Test def test_anoymousPointer() =
+    Zone {
+      val position = !StructAnonymousPointer.Struct0(1, 2)
+      val offset = !StructAnonymousPointer.Struct1(3)
+      val c = !StructAnonymousPointer.Struct2(
+        !StructAnonymousPointer.Struct2.Struct0(4)
+      )
+
+      assertEquals(1, position.x)
+      assertEquals(2, position.y)
+
+      assertEquals(3, offset.oneField)
+
+      assertEquals(4, c.nested.inner)
+    }
+
 end TestStructs


### PR DESCRIPTION
Hi 👋 , 

My attempt to fix issue #351 .

When a struct contains an anonymous inner struct used as a pointer field, the generation logic fails to resolve the correct structure type during traversal.

Example of C code: 
```c
struct MyStruct {
    struct {              
        int x;
        int y;
    } *pos;                 

    int count;
};
```

The corresponding `Def.Struct` generated  looks like this: 
```scala
Struct(
  fields = List(
    (
      ,
      Struct(
        List(
          NumericIntegral(Int, Signed),
          NumericIntegral(Int, Signed)
        ),
        Hints(8)
      )
    ),
    (
      pos,
      Pointer(Reference(Unnamed))
    ),
    (
      count,
      NumericIntegral(Int, Signed)
    )
  ),
  name = MyStruct,
  anonymous = List(
    Struct(
      List(
        (x, NumericIntegral(Int, Signed)),
        (y, NumericIntegral(Int, Signed))
      ),
      Struct0,
      List(),
      8,
      Meta(
        None,
        Some("...")
      )
    )
  ),
  staticSize = 16,
  meta = Meta(
    None,
    Some("...")
  )
)
```

**Issue:**
The `Pointer(Reference(Unnamed))` indicates an unresolved reference to the anonymous struct. This leads to incorrect code generation or runtime failure due to a missing link between the pointer field (pos) and its actual type.

Currently the code generation crash.

**Proposed fix:**
If I understand correctly, we need to reference the pointer to the right structure in `anonymous` field.

