### PR TITLE
Avoid rebinding structs when a complete definition exists

### DIFF
--- a/modules/bindgen/src/main/scala/analysis/forwardDeclaration.scala
+++ b/modules/bindgen/src/main/scala/analysis/forwardDeclaration.scala
@@ -1,0 +1,12 @@
+package bindgen
+
+import libclang.*
+import scalanative.unsafe.*
+
+// inspired from https://joshpeterson.github.io/blog/2017/identifying-a-forward-declaration-with-libclang/
+def isForwardDeclaration(cursor: CXCursor): Boolean =
+  Zone:
+    val definition = clang_getCursorDefinition(cursor)
+    val isNull = clang_equalCursors(definition, clang_getNullCursor()) != 0
+    if isNull then true
+    else clang_equalCursors(cursor, definition) == 0

--- a/modules/tests/src/test/resources/scala-native/forward_declaration.c
+++ b/modules/tests/src/test/resources/scala-native/forward_declaration.c
@@ -1,0 +1,5 @@
+#include "forward_declaration.h"
+
+void uselessUsingForwardStruct(struct ForwardStructSimple* s) {
+    (void)s; 
+}

--- a/modules/tests/src/test/resources/scala-native/forward_declaration.h
+++ b/modules/tests/src/test/resources/scala-native/forward_declaration.h
@@ -1,0 +1,8 @@
+#ifndef FORWARD_DECLARATION_H
+#define FORWARD_DECLARATION_H
+
+#include "forward_struct.h"
+struct ForwardStructSimple;
+
+void uselessUsingForwardStruct(struct ForwardStructSimple* s);
+#endif

--- a/modules/tests/src/test/resources/scala-native/forward_entrypoint.h
+++ b/modules/tests/src/test/resources/scala-native/forward_entrypoint.h
@@ -1,0 +1,2 @@
+#include "forward_declaration.h"
+#include "forward_struct.h"

--- a/modules/tests/src/test/resources/scala-native/forward_struct.h
+++ b/modules/tests/src/test/resources/scala-native/forward_struct.h
@@ -1,0 +1,8 @@
+#ifndef FORWARD_STRUCT_H
+#define FORWARD_STRUCT_H
+
+typedef struct ForwardStructSimple {
+    int x, y;
+    char *s1, *s2;
+} ForwardStructSimple;
+#endif


### PR DESCRIPTION
Hi 👋 

I found a weird behavior, and not being a C developer, will be difficult to explain :) .
When parsing C headers, it's possible for the same `struct` to be declared multiple times. (forward declaration)

Currently, sn-bindgen does not distinguish correctly between these cases.
1. the forward declaration may be parsed and bound first
2. the complete definition may be ignored later (because the name is already present in binding.named)
3. the final generated binding contains an incomplete struct without fields

**Proposed fix:**
Try to detect forward declaration and don't add them to the binding. 


I didn't write the tests because I'm not sure how to reproduce the bug. 
