### PR TITLE
Fully qualify calls to alloc in forwarders

### DIFF
--- a/modules/bindgen/src/main/scala/render/function.scala
+++ b/modules/bindgen/src/main/scala/render/function.scala
@@ -118,7 +118,7 @@ def renderFunction(
         typeIndices.foreach { (ct, i) =>
           val typ = scalaType(ct)
           line(
-            s"val __ptr_$i: Ptr[$typ] = alloc[$typ](${allocationSizes(ct)})"
+            s"val __ptr_$i: Ptr[$typ] = _root_.scala.scalanative.unsafe.alloc[$typ](${allocationSizes(ct)})"
           )
         }
         indices.toList.sorted.foreach { idx =>

--- a/modules/bindgen/src/main/scala/render/union.scala
+++ b/modules/bindgen/src/main/scala/render/union.scala
@@ -42,7 +42,7 @@ def union(model: Def.Union, line: Appender)(using Config)(using
     if model.fields.nonEmpty then
       line(s"def apply()(using Zone): Ptr[$unionName] = ")
       nest {
-        line(s"val ___ptr = alloc[$unionName](1)")
+        line(s"val ___ptr = _root_.scala.scalanative.unsafe.alloc[$unionName](1)")
         line("___ptr")
       }
       model.fields.foreach { case (fieldName, fieldType) =>
@@ -55,7 +55,7 @@ def union(model: Def.Union, line: Appender)(using Config)(using
           s"def apply($getterName: $typ)(using Zone): Ptr[$unionName] ="
         )
         nest {
-          line(s"val ___ptr = alloc[$unionName](1)")
+          line(s"val ___ptr = _root_.scala.scalanative.unsafe.alloc[$unionName](1)")
           line(s"val un = !___ptr")
           line(
             s"un.at(0).asInstanceOf[Ptr[$typ]].update(0, $getterName)"

--- a/modules/bindgen/src/main/scala/render/union.scala
+++ b/modules/bindgen/src/main/scala/render/union.scala
@@ -42,7 +42,9 @@ def union(model: Def.Union, line: Appender)(using Config)(using
     if model.fields.nonEmpty then
       line(s"def apply()(using Zone): Ptr[$unionName] = ")
       nest {
-        line(s"val ___ptr = _root_.scala.scalanative.unsafe.alloc[$unionName](1)")
+        line(
+          s"val ___ptr = _root_.scala.scalanative.unsafe.alloc[$unionName](1)"
+        )
         line("___ptr")
       }
       model.fields.foreach { case (fieldName, fieldType) =>
@@ -55,7 +57,9 @@ def union(model: Def.Union, line: Appender)(using Config)(using
           s"def apply($getterName: $typ)(using Zone): Ptr[$unionName] ="
         )
         nest {
-          line(s"val ___ptr = _root_.scala.scalanative.unsafe.alloc[$unionName](1)")
+          line(
+            s"val ___ptr = _root_.scala.scalanative.unsafe.alloc[$unionName](1)"
+          )
           line(s"val un = !___ptr")
           line(
             s"un.at(0).asInstanceOf[Ptr[$typ]].update(0, $getterName)"

--- a/modules/tests/src/test/resources/scala-native/scala_keywords.c
+++ b/modules/tests/src/test/resources/scala-native/scala_keywords.c
@@ -1,0 +1,5 @@
+#include "scala_keywords.h"
+
+void test_alloc_collision(int alloc, StructKeywords the_struct) {
+  return;
+}

--- a/modules/tests/src/test/resources/scala-native/scala_keywords.h
+++ b/modules/tests/src/test/resources/scala-native/scala_keywords.h
@@ -24,3 +24,5 @@ typedef struct test_keywords_struct {
   int wait;
   int macro;
 } StructKeywords;
+
+void test_alloc_collision(int alloc, StructKeywords the_struct);


### PR DESCRIPTION
(And unions, for consistency).

Fixes #352.

The test fails without the fix, and when I run `devPublish` and use the snapshot in https://github.com/dhpiggott/plutus the generated code compiles without issue. So I think this is good.

However, when adding the test, I noticed `function_rewrites.h`, and wondered if the test would be better placed there. Happy to move it if so, but thought it best (at least initially) to go with your direction.