### PR TITLE
add compatibility with compiler option `-no-indent`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ docs/mdoc-invocation.txt
 local-bindgen
 bin
 worktree-main
+/.idea/

--- a/modules/bindgen/src/main/scala/Config.scala
+++ b/modules/bindgen/src/main/scala/Config.scala
@@ -26,7 +26,7 @@ case class Config(
     linkName: Option[LinkName],
     indentSize: IndentationSize,
     indents: Indentation,
-    bracesNotIndents: Braces,
+    useBraces: UseBraces,
     cImports: List[CImport],
     clangFlags: List[ClangFlag],
     quiet: Quiet,
@@ -57,7 +57,7 @@ object Config:
       linkName = None,
       indentSize = defaults.indentSize,
       indents = defaults.indents,
-      bracesNotIndents = Braces.No,
+      useBraces = UseBraces.No,
       cImports = Nil,
       clangFlags = Nil,
       quiet = Quiet.No,
@@ -101,8 +101,8 @@ object Quiet extends YesNo[Quiet]
 opaque type MultiFile = Boolean
 object MultiFile extends YesNo[MultiFile]
 
-opaque type Braces = Boolean
-object Braces extends YesNo[Braces]
+opaque type UseBraces = Boolean
+object UseBraces extends YesNo[UseBraces]
 
 enum Lang:
   case Scala, C

--- a/modules/bindgen/src/main/scala/Config.scala
+++ b/modules/bindgen/src/main/scala/Config.scala
@@ -26,6 +26,7 @@ case class Config(
     linkName: Option[LinkName],
     indentSize: IndentationSize,
     indents: Indentation,
+    bracesNotIndents: Braces,
     cImports: List[CImport],
     clangFlags: List[ClangFlag],
     quiet: Quiet,
@@ -56,6 +57,7 @@ object Config:
       linkName = None,
       indentSize = defaults.indentSize,
       indents = defaults.indents,
+      bracesNotIndents = Braces.No,
       cImports = Nil,
       clangFlags = Nil,
       quiet = Quiet.No,
@@ -98,6 +100,9 @@ object Quiet extends YesNo[Quiet]
 
 opaque type MultiFile = Boolean
 object MultiFile extends YesNo[MultiFile]
+
+opaque type Braces = Boolean
+object Braces extends YesNo[Braces]
 
 enum Lang:
   case Scala, C

--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -83,7 +83,7 @@ object CLI:
   private val bracesNotIndents =
     Opts
       .flag(
-        "no-indents",
+        "no-indent",
         help =
           "Generate Scala part of the binding with braces or significant whitespace"
       )

--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -83,12 +83,12 @@ object CLI:
   private val bracesNotIndents =
     Opts
       .flag(
-        "no-indent",
+        "use-braces",
         help =
           "Generate Scala part of the binding with braces or significant whitespace"
       )
       .orFalse
-      .map(Braces.apply(_))
+      .map(UseBraces.apply(_))
 
   private val isScala =
     Opts.flag("scala", help = "Generate Scala part of the binding").orFalse

--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -80,6 +80,16 @@ object CLI:
     .withDefault(2)
     .map(IndentationSize.apply(_))
 
+  private val bracesNotIndents =
+    Opts
+      .flag(
+        "no-indents",
+        help =
+          "Generate Scala part of the binding with braces or significant whitespace"
+      )
+      .orFalse
+      .map(Braces.apply(_))
+
   private val isScala =
     Opts.flag("scala", help = "Generate Scala part of the binding").orFalse
 
@@ -378,6 +388,7 @@ object CLI:
       linkName,
       indentationSize,
       indentation,
+      bracesNotIndents,
       cImport,
       (clangInclude, clangFlag).mapN(_ ++ _),
       quiet,

--- a/modules/bindgen/src/main/scala/render/alias.scala
+++ b/modules/bindgen/src/main/scala/render/alias.scala
@@ -9,6 +9,14 @@ def alias(model: Def.Alias, line: Appender)(using
     AliasResolver,
     Config
 ): Exported =
+
+  val openDelimiter =
+    if summon[Config].bracesNotIndents.value then " {" else ":"
+  val openDefDelimiter =
+    if summon[Config].bracesNotIndents.value then "{" else ""
+  def appendCloseDelimiter(): Unit =
+    if summon[Config].bracesNotIndents.value then line("}") else ()
+
   val (underlyingType, enableConstructor) =
     model.underlying match
       case Pointer(Reference(Name.Unnamed)) =>
@@ -31,7 +39,7 @@ def alias(model: Def.Alias, line: Appender)(using
 
   renderComment(line, model.meta)
   line(s"${modifier}type ${model.name} = ${scalaType(underlyingType)}")
-  line(s"object ${sanitiseBeforeColon(model.name)}: ")
+  line(s"object ${sanitiseBeforeColon(model.name)}$openDelimiter")
   nest {
     model.underlying match
       case Reference(Name.BuiltIn(name)) =>
@@ -50,15 +58,17 @@ def alias(model: Def.Alias, line: Appender)(using
       line(
         s"inline def apply(inline o: ${scalaType(underlyingType)}): ${model.name} = o"
       )
-      line(s"extension (v: ${model.name})")
+      line(s"extension (v: ${model.name}) $openDefDelimiter")
       nest {
         line(s"inline def value: ${scalaType(underlyingType)} = v")
         if isFunctionPointer then
           line(s"inline def toPtr: $voidPtr = CFuncPtr.toPtr(v)")
         end if
       }
+      appendCloseDelimiter()
     end if
   }
+  appendCloseDelimiter()
 
   Exported.Yes(model.name)
 

--- a/modules/bindgen/src/main/scala/render/binding.scala
+++ b/modules/bindgen/src/main/scala/render/binding.scala
@@ -2,7 +2,6 @@ package bindgen
 package rendering
 
 import bindgen.*
-import bindgen.rendering.RenderMode.Objects
 import opaque_newtypes.given
 
 case class Constants(enums: Seq[Def.Enum])
@@ -254,9 +253,9 @@ private def maybeObjectBlock(out: LineBuilder, mode: RenderMode)(
     f: Config ?=> Unit
 )(using Config) =
   lazy val openDelimiter: String =
-    if summon[Config].bracesNotIndents.value then "{" else ":"
+    if summon[Config].useBraces.value then " {" else ":"
   lazy val closeDelimiter: Option[String] =
-    if summon[Config].bracesNotIndents.value then Some("}") else None
+    if summon[Config].useBraces.value then Some("}") else None
 
   if mode == RenderMode.Objects then to(out)(s"$objectHeader$openDelimiter")
   nestIf(mode == RenderMode.Objects) {

--- a/modules/bindgen/src/main/scala/render/enumeration.scala
+++ b/modules/bindgen/src/main/scala/render/enumeration.scala
@@ -12,18 +12,9 @@ def enumeration(model: Def.Enum, line: Appender)(using
   val underlyingTypeRender = scalaType(numericType)
   val traitName = enumBaseTraitName(numericType)
 
-  val openDelimiter =
-    if summon[Config].bracesNotIndents.value then " {" else ":"
-  val openDefDelimiter =
-    if summon[Config].bracesNotIndents.value then "{" else ""
-  def appendCloseDelimiter(): Unit =
-    if summon[Config].bracesNotIndents.value then line("}") else ()
-
   renderComment(line, model.meta)
   line(s"opaque type $opaqueType = $underlyingTypeRender")
-  line(s"object $opaqueType extends $traitName[$opaqueType]$openDelimiter")
-
-  nest {
+  objectBlock(line)(s"object $opaqueType extends $traitName[$opaqueType]") {
     line(s"given _tag: Tag[$opaqueType] = ${scalaTag(numericType)}")
     if numericType.sign == SignType.Signed then
       line(
@@ -45,43 +36,36 @@ def enumeration(model: Def.Enum, line: Appender)(using
 
       line(lhs + " = " + rhs)
     }
-    line(
-      s"inline def getName(inline value: $opaqueType): Option[String] = $openDefDelimiter"
-    )
-    nest {
-      line(s"inline value match $openDefDelimiter")
-      nest {
+    defBlock(line)(
+      s"inline def getName(inline value: $opaqueType): Option[String] ="
+    ) {
+      defBlock(line)("inline value match") {
         model.values.foreach { case (constName, value) =>
           line(s"""case ${escape(constName)} => Some("${escape(constName)}")""")
         }
         line("case _ => _root_.scala.None")
       }
-      appendCloseDelimiter()
     }
-    appendCloseDelimiter()
-    line(s"extension (a: $opaqueType) $openDefDelimiter")
-    def wrap(exp: String) =
-      numericType match
-        case CType.NumericIntegral(
-              bindgen.IntegralBase.Char,
-              SignType.Signed
-            ) =>
-          s"(($exp) & 0xff).toByte"
-        case CType.NumericIntegral(
-              bindgen.IntegralBase.Char,
-              SignType.Unsigned
-            ) =>
-          s"(($exp) & 0xff.toUInt).toUByte"
-        case _ => exp
+    defBlock(line)(s"extension (a: $opaqueType)") {
+      def wrap(exp: String) =
+        numericType match
+          case CType.NumericIntegral(
+                bindgen.IntegralBase.Char,
+                SignType.Signed
+              ) =>
+            s"(($exp) & 0xff).toByte"
+          case CType.NumericIntegral(
+                bindgen.IntegralBase.Char,
+                SignType.Unsigned
+              ) =>
+            s"(($exp) & 0xff.toUInt).toUByte"
+          case _ => exp
 
-    nest {
       line(s"inline def &(b: $opaqueType): $opaqueType = ${wrap("a & b")}")
       line(s"inline def |(b: $opaqueType): $opaqueType = ${wrap("a | b")}")
       line(s"inline def is(b: $opaqueType): Boolean = (a & b) == b")
     }
-    appendCloseDelimiter()
   }
-  appendCloseDelimiter()
 
   Exported.Yes(opaqueType.value)
 end enumeration

--- a/modules/bindgen/src/main/scala/render/enumeration.scala
+++ b/modules/bindgen/src/main/scala/render/enumeration.scala
@@ -12,9 +12,16 @@ def enumeration(model: Def.Enum, line: Appender)(using
   val underlyingTypeRender = scalaType(numericType)
   val traitName = enumBaseTraitName(numericType)
 
+  val openDelimiter =
+    if summon[Config].bracesNotIndents.value then " {" else ":"
+  val openDefDelimiter =
+    if summon[Config].bracesNotIndents.value then "{" else ""
+  def appendCloseDelimiter(): Unit =
+    if summon[Config].bracesNotIndents.value then line("}") else ()
+
   renderComment(line, model.meta)
   line(s"opaque type $opaqueType = $underlyingTypeRender")
-  line(s"object $opaqueType extends $traitName[$opaqueType]:")
+  line(s"object $opaqueType extends $traitName[$opaqueType]$openDelimiter")
 
   nest {
     line(s"given _tag: Tag[$opaqueType] = ${scalaTag(numericType)}")
@@ -38,17 +45,21 @@ def enumeration(model: Def.Enum, line: Appender)(using
 
       line(lhs + " = " + rhs)
     }
-    line(s"inline def getName(inline value: $opaqueType): Option[String] =")
+    line(
+      s"inline def getName(inline value: $opaqueType): Option[String] = $openDefDelimiter"
+    )
     nest {
-      line("inline value match")
+      line(s"inline value match $openDefDelimiter")
       nest {
         model.values.foreach { case (constName, value) =>
           line(s"""case ${escape(constName)} => Some("${escape(constName)}")""")
         }
         line("case _ => _root_.scala.None")
       }
+      appendCloseDelimiter()
     }
-    line(s"extension (a: $opaqueType)")
+    appendCloseDelimiter()
+    line(s"extension (a: $opaqueType) $openDefDelimiter")
     def wrap(exp: String) =
       numericType match
         case CType.NumericIntegral(
@@ -68,7 +79,9 @@ def enumeration(model: Def.Enum, line: Appender)(using
       line(s"inline def |(b: $opaqueType): $opaqueType = ${wrap("a | b")}")
       line(s"inline def is(b: $opaqueType): Boolean = (a & b) == b")
     }
+    appendCloseDelimiter()
   }
+  appendCloseDelimiter()
 
   Exported.Yes(opaqueType.value)
 end enumeration

--- a/modules/bindgen/src/main/scala/render/function.scala
+++ b/modules/bindgen/src/main/scala/render/function.scala
@@ -29,6 +29,11 @@ def renderFunction(
     if f.public then ""
     else s"private[${summon[Context].packageName.value.split('.').last}] "
 
+  val openDefDelimiter =
+    if summon[Config].bracesNotIndents.value then "{" else ""
+  def appendCloseDelimiter(): Unit =
+    if summon[Config].bracesNotIndents.value then line("}") else ()
+
   if f.public then f.meta.foreach(renderComment(line, _))
   f.body match
     case ScalaFunctionBody.Export(loc) =>
@@ -74,7 +79,7 @@ def renderFunction(
         ) =>
       val hasZone = if a.hasAny then "(using Zone)" else ""
       line(
-        s"def ${f.name}$arglist$hasZone: ${scalaType(f.returnType)} = "
+        s"def ${f.name}$arglist$hasZone: ${scalaType(f.returnType)} = $openDefDelimiter"
       )
       nest {
         import scala.collection.mutable.Map as MutableMap
@@ -139,6 +144,7 @@ def renderFunction(
         line(s"$to(${delegateCallArgList.map(escape).mkString(", ")})")
         if returnAsWell then line(s"!${return_ptr}")
       }
+      appendCloseDelimiter()
 
       Exported.Yes(f.name.value)
   end match

--- a/modules/bindgen/src/main/scala/render/struct.scala
+++ b/modules/bindgen/src/main/scala/render/struct.scala
@@ -41,10 +41,10 @@ def struct(struct: Def.Struct, line: Appender)(using
     if summon[Config].bracesNotIndents.value then " {" else ":"
   val openDefDelimiter =
     if summon[Config].bracesNotIndents.value then "{" else ""
-  def appendCloseDelimiter(): Unit =
-    if summon[Config].bracesNotIndents.value then line("}") else ()
-  def appendDefCloseDelimiter(name: String): Unit =
-    if summon[Config].bracesNotIndents.value then line("}")
+  def appendCloseDelimiter()(using c: Config): Unit =
+    if c.bracesNotIndents.value then line("}") else ()
+  def appendDefCloseDelimiter(name: String)(using c: Config): Unit =
+    if c.bracesNotIndents.value then line("}")
     else line(s"end $name")
 
   def setter(name: String): String =

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -91,6 +91,32 @@ def to(sb: LineBuilder)(using config: Config): Appender =
 def aliasResolver(name: String)(using ar: AliasResolver): CType =
   ar(name)
 
+//objects, traits, classes
+def objectBlock(line: Appender)(start: String)(
+    f: Config ?=> Unit
+)(using config: Config): Unit =
+  val startDelimiter = if config.bracesNotIndents.value then " {" else ":"
+  line(start + startDelimiter)
+  nest {
+    f
+  }
+  if config.bracesNotIndents.value then line("}")
+
+//defs, vals, extensions
+def defBlock(
+    line: Appender
+)(start: String, defNameForEnd: Option[String] = None)(
+    f: Config ?=> Unit
+)(using config: Config): Unit =
+  val startDelimiter = if config.bracesNotIndents.value then " {" else ""
+  line(start + startDelimiter)
+  nest {
+    f
+  }
+  if config.bracesNotIndents.value then line("}")
+  else defNameForEnd.foreach(n => line(s"end $n"))
+end defBlock
+
 def packageName(using conf: Context): String = conf.packageName.value
 
 type Appender = Config ?=> String => Unit

--- a/modules/bindgen/src/main/scala/render/utils.scala
+++ b/modules/bindgen/src/main/scala/render/utils.scala
@@ -95,12 +95,12 @@ def aliasResolver(name: String)(using ar: AliasResolver): CType =
 def objectBlock(line: Appender)(start: String)(
     f: Config ?=> Unit
 )(using config: Config): Unit =
-  val startDelimiter = if config.bracesNotIndents.value then " {" else ":"
+  val startDelimiter = if config.useBraces.value then " {" else ":"
   line(start + startDelimiter)
   nest {
     f
   }
-  if config.bracesNotIndents.value then line("}")
+  if config.useBraces.value then line("}")
 
 //defs, vals, extensions
 def defBlock(
@@ -108,12 +108,12 @@ def defBlock(
 )(start: String, defNameForEnd: Option[String] = None)(
     f: Config ?=> Unit
 )(using config: Config): Unit =
-  val startDelimiter = if config.bracesNotIndents.value then " {" else ""
+  val startDelimiter = if config.useBraces.value then " {" else ""
   line(start + startDelimiter)
   nest {
     f
   }
-  if config.bracesNotIndents.value then line("}")
+  if config.useBraces.value then line("}")
   else defNameForEnd.foreach(n => line(s"end $n"))
 end defBlock
 

--- a/modules/interface/src/main/scala/Binding.scala
+++ b/modules/interface/src/main/scala/Binding.scala
@@ -28,7 +28,7 @@ class Binding private (
   def scalaFile: String = impl.scalaFile
   def cFile: String = impl.cFile
   def flavour: Option[Flavour] = impl.flavour
-  def bracesNotIndents: Boolean = impl.bracesNotIndents
+  def useBraces: Boolean = impl.useBraces
 
   def withLinkName(name: String) = copy(_.copy(linkName = Some(name)))
 
@@ -117,8 +117,8 @@ class Binding private (
   def addBindgenArguments(arguments: List[String]): Binding =
     copy(b => b.copy(bindgenArguments = b.bindgenArguments ++ arguments))
 
-  def withBracesNotIndents(b: Boolean): Binding =
-    copy(_.copy(bracesNotIndents = b))
+  def withBraces(b: Boolean): Binding =
+    copy(_.copy(useBraces = b))
 
   def toCommand(lang: BindingLang): List[String] = {
     val sb = List.newBuilder[String]
@@ -161,8 +161,7 @@ class Binding private (
     else
       flag("c")
 
-    if (bracesNotIndents) flag("no-indents")
-
+    if (useBraces && lang == BindingLang.Scala) flag("use-braces")
     if (multiFile && lang == BindingLang.Scala) flag("multi-file")
     if (noComments && lang == BindingLang.Scala) flag("render.no-comments")
     if (noLocation && lang == BindingLang.Scala) flag("render.no-location")
@@ -241,7 +240,7 @@ object Binding {
       multiFile: Boolean = Defaults.multiFile,
       noComments: Boolean = Defaults.noComments,
       noLocation: Boolean = Defaults.noLocation,
-      bracesNotIndents: Boolean = Defaults.bracesNotIndents
+      bracesNotIndents: Boolean = Defaults.useBraces
   ): Binding = {
     apply(headerFile, packageName).copy(
       _.copy(
@@ -256,7 +255,7 @@ object Binding {
         multiFile = multiFile,
         noComments = noComments,
         noLocation = noLocation,
-        bracesNotIndents = bracesNotIndents
+        useBraces = bracesNotIndents
       )
     )
   }
@@ -283,7 +282,7 @@ object Binding {
       flavour: Option[Flavour] = None,
       scalaFile: String,
       cFile: String,
-      bracesNotIndents: Boolean = Defaults.bracesNotIndents
+      useBraces: Boolean = Defaults.useBraces
   )
 
   private[interface] object Defaults {
@@ -304,7 +303,7 @@ object Binding {
     val excludeSystemPaths = List.empty[Path]
     val exportMode = false
     val flavour = Flavour.ScalaNative04
-    val bracesNotIndents = false
+    val useBraces = false
   }
 
 }

--- a/modules/interface/src/main/scala/Binding.scala
+++ b/modules/interface/src/main/scala/Binding.scala
@@ -28,6 +28,7 @@ class Binding private (
   def scalaFile: String = impl.scalaFile
   def cFile: String = impl.cFile
   def flavour: Option[Flavour] = impl.flavour
+  def bracesNotIndents: Boolean = impl.bracesNotIndents
 
   def withLinkName(name: String) = copy(_.copy(linkName = Some(name)))
 
@@ -116,6 +117,9 @@ class Binding private (
   def addBindgenArguments(arguments: List[String]): Binding =
     copy(b => b.copy(bindgenArguments = b.bindgenArguments ++ arguments))
 
+  def withBracesNotIndents(b: Boolean): Binding =
+    copy(_.copy(bracesNotIndents = b))
+
   def toCommand(lang: BindingLang): List[String] = {
     val sb = List.newBuilder[String]
 
@@ -156,6 +160,8 @@ class Binding private (
       flag("scala")
     else
       flag("c")
+
+    if (bracesNotIndents) flag("no-indents")
 
     if (multiFile && lang == BindingLang.Scala) flag("multi-file")
     if (noComments && lang == BindingLang.Scala) flag("render.no-comments")
@@ -234,7 +240,8 @@ object Binding {
       opaqueStructs: Set[String] = Defaults.opaqueStructs,
       multiFile: Boolean = Defaults.multiFile,
       noComments: Boolean = Defaults.noComments,
-      noLocation: Boolean = Defaults.noLocation
+      noLocation: Boolean = Defaults.noLocation,
+      bracesNotIndents: Boolean = Defaults.bracesNotIndents
   ): Binding = {
     apply(headerFile, packageName).copy(
       _.copy(
@@ -248,7 +255,8 @@ object Binding {
         opaqueStructs = opaqueStructs,
         multiFile = multiFile,
         noComments = noComments,
-        noLocation = noLocation
+        noLocation = noLocation,
+        bracesNotIndents = bracesNotIndents
       )
     )
   }
@@ -274,7 +282,8 @@ object Binding {
       excludeSystemPaths: List[Path] = Defaults.excludeSystemPaths,
       flavour: Option[Flavour] = None,
       scalaFile: String,
-      cFile: String
+      cFile: String,
+      bracesNotIndents: Boolean = Defaults.bracesNotIndents
   )
 
   private[interface] object Defaults {
@@ -295,6 +304,7 @@ object Binding {
     val excludeSystemPaths = List.empty[Path]
     val exportMode = false
     val flavour = Flavour.ScalaNative04
+    val bracesNotIndents = false
   }
 
 }

--- a/modules/sbt-plugin/src/main/scala/BindgenPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/BindgenPlugin.scala
@@ -191,9 +191,9 @@ object BindgenPlugin extends AutoPlugin {
         b.flavour match {
           case None =>
             b.withFlavour(bindgenFlavour.value)
-              .withBracesNotIndents(scalacOptions.value.contains("-no-indent"))
+              .withBraces(scalacOptions.value.contains("-no-indent"))
           case Some(_) =>
-            b.withBracesNotIndents(scalacOptions.value.contains("-no-indent"))
+            b.withBraces(scalacOptions.value.contains("-no-indent"))
         }
       }
 

--- a/modules/sbt-plugin/src/main/scala/BindgenPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/BindgenPlugin.scala
@@ -189,8 +189,11 @@ object BindgenPlugin extends AutoPlugin {
     bindgenGenerateScalaSources := {
       val selected = (addConf / bindgenBindings).value.map { b =>
         b.flavour match {
-          case None    => b.withFlavour(bindgenFlavour.value)
-          case Some(_) => b
+          case None =>
+            b.withFlavour(bindgenFlavour.value)
+              .withBracesNotIndents(scalacOptions.value.contains("-no-indent"))
+          case Some(_) =>
+            b.withBracesNotIndents(scalacOptions.value.contains("-no-indent"))
         }
       }
 


### PR DESCRIPTION
see #353 

This PR adds support for projects that use the compiler option `-no-indent`. As part of the sbt plugin it checks whether the build has the -no-indent compiler option set and swap whitespace for braces accordingly. 
Also adds a CLI option for generating sources with braces.