### PR TITLE
Fix C code generation for function pointer parameters (#378)

### DIFF
--- a/modules/bindgen/src/main/scala/render/c_function_forwarder.scala
+++ b/modules/bindgen/src/main/scala/render/c_function_forwarder.scala
@@ -3,6 +3,19 @@ package rendering
 
 import scala.collection.mutable.ListBuffer
 
+// Pattern to match function pointer types like "void (*)(void *)"
+// Captures: group 1 = return type and opening, group 2 = params
+private val funcPtrPattern = """^(.+\(\*)(\)\(.*)$""".r
+
+// Render a C parameter with correct syntax for function pointers
+private def renderCParam(typeStr: String, name: String): String =
+  typeStr match
+    case funcPtrPattern(prefix, suffix) =>
+      // "void (*)(void *)" -> "void (*name)(void *)"
+      s"$prefix$name$suffix"
+    case _ =>
+      s"$typeStr $name"
+
 def cFunctionForwarder(f: GeneratedFunction.CFunction, line: Appender)(using
     AliasResolver,
     Config
@@ -14,7 +27,7 @@ def cFunctionForwarder(f: GeneratedFunction.CFunction, line: Appender)(using
         .foreach { case (fp, i) =>
           arglist.addOne {
             if pointers.contains(i) then s"${fp.originalTyp.s} *${fp.name}"
-            else s"${fp.originalTyp.s} ${fp.name}"
+            else renderCParam(fp.originalTyp.s, fp.name)
           }
         }
 

--- a/modules/bindgen/src/test/scala/TestFunctionPointerRendering.scala
+++ b/modules/bindgen/src/test/scala/TestFunctionPointerRendering.scala
@@ -1,0 +1,102 @@
+package bindgen
+
+import org.junit.Assert.*
+import org.junit.Test
+
+import bindgen.rendering.*
+
+class TestFunctionPointerRendering:
+
+  // Helper to create a minimal Config for testing
+  given Config = Config.withDefaults()
+
+  // Helper to create a minimal AliasResolver for testing
+  given AliasResolver = AliasResolver(_ => CType.Void)
+
+  @Test def test_function_pointer_parameter_rendering(): Unit =
+    // Test case for issue #378: function pointer parameters should be rendered as
+    // "void (*callback)(void *)" not "void (*)(void *) callback"
+
+    val lb = LineBuilder()
+    val line: Appender = s => lb.appendLine(s)
+
+    val funcPtrParam = FunctionParameter(
+      name = "callback",
+      typ = CType.Function(
+        CType.Void,
+        List(CType.Parameter(None, CType.Pointer(CType.Void)))
+      ),
+      originalTyp = OriginalCType(
+        CType.Function(
+          CType.Void,
+          List(CType.Parameter(None, CType.Pointer(CType.Void)))
+        ),
+        "void (*)(void *)" // This is what libclang returns
+      ),
+      generatedName = false
+    )
+
+    val func: GeneratedFunction.CFunction = GeneratedFunction.CFunction(
+      name = CFunctionName("test_func"),
+      returnType = CType.Void,
+      originalCType = OriginalCType(CType.Void, "void"),
+      arguments = List(funcPtrParam),
+      body = CFunctionBody.Delegate(
+        to = CFunctionName("original_func"),
+        dereference = Set.empty,
+        returnAsWell = false
+      )
+    )
+
+    cFunctionForwarder(func, line)
+
+    val result = lb.result
+    // Should contain "void (*callback)(void *)" not "void (*)(void *) callback"
+    assertTrue(
+      s"Expected 'void (*callback)(void *)' in output, but got: $result",
+      result.contains("void (*callback)(void *)")
+    )
+    assertFalse(
+      s"Should not contain 'void (*)(void *) callback' in output, but got: $result",
+      result.contains("void (*)(void *) callback")
+    )
+  end test_function_pointer_parameter_rendering
+
+  @Test def test_non_function_pointer_parameter_unchanged(): Unit =
+    // Ensure regular (non-function-pointer) parameters still work
+
+    val lb = LineBuilder()
+    val line: Appender = s => lb.appendLine(s)
+
+    val regularParam = FunctionParameter(
+      name = "value",
+      typ = CType.NumericIntegral(IntegralBase.Int, SignType.Signed),
+      originalTyp = OriginalCType(
+        CType.NumericIntegral(IntegralBase.Int, SignType.Signed),
+        "int"
+      ),
+      generatedName = false
+    )
+
+    val func: GeneratedFunction.CFunction = GeneratedFunction.CFunction(
+      name = CFunctionName("test_regular_func"),
+      returnType = CType.Void,
+      originalCType = OriginalCType(CType.Void, "void"),
+      arguments = List(regularParam),
+      body = CFunctionBody.Delegate(
+        to = CFunctionName("original_regular_func"),
+        dereference = Set.empty,
+        returnAsWell = false
+      )
+    )
+
+    cFunctionForwarder(func, line)
+
+    val result = lb.result
+    assertTrue(
+      s"Expected 'int value' in output, but got: $result",
+      result.contains("int value")
+    )
+  end test_non_function_pointer_parameter_unchanged
+
+end TestFunctionPointerRendering


### PR DESCRIPTION
When generating C glue code for functions with function pointer parameters, the tool was producing invalid syntax like "void (*)(void *) callback" instead of "void (*callback)(void *)".

Added regex pattern to detect function pointer types and insert the parameter name in the correct position.