### PR TITLE
Fix incorrect handling of --render.external-path flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         shell: pwsh
         run: |
           choco install llvm --version="$Env:LLVM_VERSION" --allow-downgrade
-          choco install sbt --version=1.11.7
+          choco install sbt --version=1.12.8
           clang --version
 
       - name: SBT remote cache

--- a/build.sbt
+++ b/build.sbt
@@ -832,8 +832,8 @@ addCommandAlias(
 addCommandAlias("interfaceTests", "tests/test; tests3/test; tests2_12/test")
 addCommandAlias(
   "ci",
-  "clean; scalafixEnable; scalafmtCheckAll; scalafmtSbtCheck; cliTests;" +
-    "interfaceTests; pluginTests; generatorTests; exportTests"
+  "clean; scalafixEnable; scalafmtCheckAll; scalafmtSbtCheck; generatorTests; cliTests;" +
+    "interfaceTests; pluginTests;  exportTests"
 )
 
 addCommandAlias(

--- a/modules/bindgen/src/main/scala/main.scala
+++ b/modules/bindgen/src/main/scala/main.scala
@@ -4,12 +4,23 @@ import bindgen.rendering.*
 import com.monovore.decline.HelpFormat
 
 import java.io.{File, FileWriter}
+import java.lang.Thread.UncaughtExceptionHandler
 import java.nio.file.Files
 import scala.scalanative.unsafe.*
 import scala.util.Using
 
 object Generate:
   def main(args: Array[String]): Unit =
+    Thread
+      .currentThread()
+      .setUncaughtExceptionHandler(
+        new UncaughtExceptionHandler:
+          override def uncaughtException(x: Thread, t: Throwable): Unit =
+            println(x)
+            println(t.getMessage())
+            println("Stacktrace: ")
+            x.getStackTrace().foreach(println)
+      )
     val arguments = args.takeWhile(_ != "--")
     val rest = args.drop(arguments.length + 1)
     Zone:

--- a/modules/bindgen/src/main/scala/render/BindingInfo.scala
+++ b/modules/bindgen/src/main/scala/render/BindingInfo.scala
@@ -2,6 +2,7 @@ package bindgen
 package rendering
 
 class BindingInfo(rawBinding: Binding)(using Config, Context):
+  // TODO: make it work with resolved versions
   private def shouldRender(definition: Def)(using config: Config) =
     definition.defName
       .map(_.n)
@@ -73,10 +74,12 @@ class BindingInfo(rawBinding: Binding)(using Config, Context):
 
   val exportMode = summon[Config].exportMode
 
-  val all = rawBinding.resolve
+  private val all = binding.resolve
 
   val aliasResolver =
-    AliasResolver.create(all)
+    // NOTE: We are using raw binding here to make sure that the information about all types is present
+    // Even though some of those types won't be rendered (if filtered by [[shouldRender]] above)
+    AliasResolver.create(rawBinding.resolve)
 
   val resolvedFunctions: scala.collection.mutable.Set[GeneratedFunction] =
     deduplicateFunctions(binding.functions).flatMap(

--- a/modules/bindgen/src/main/scala/render/scalaType.scala
+++ b/modules/bindgen/src/main/scala/render/scalaType.scala
@@ -34,7 +34,7 @@ def scalaNumericType(typ: CType.NumericIntegral) =
   prefix + bs
 end scalaNumericType
 
-def scalaType(typ: CType)(using AliasResolver, Config): String =
+def scalaType(typ: CType)(using Config): String =
   import CType.*
   typ match
     case Reference(n: Name.Model) =>
@@ -91,7 +91,7 @@ def scalaType(typ: CType)(using AliasResolver, Config): String =
   end match
 end scalaType
 
-def structArrayType(ct: CType.Struct)(using Config, AliasResolver) =
+def structArrayType(ct: CType.Struct) =
   CType.Arr(CType.Byte, Some(ct.hints.staticSize.toInt))
 
 def natDigits(i: Long): String =

--- a/modules/tests/src/test/resources/scala-native/external_paths.c
+++ b/modules/tests/src/test/resources/scala-native/external_paths.c
@@ -1,0 +1,5 @@
+#include "external_paths.h"
+
+int my_func(my_struct test) {
+    return test.hello * 11;
+}

--- a/modules/tests/src/test/resources/scala-native/external_paths.h
+++ b/modules/tests/src/test/resources/scala-native/external_paths.h
@@ -1,0 +1,5 @@
+//!bindgen: --render.external-path */external_paths.inc.h=lib_test_external_paths_inc.all
+
+#include "external_paths_inc.h"
+
+int my_func(my_struct test);

--- a/modules/tests/src/test/resources/scala-native/external_paths.h
+++ b/modules/tests/src/test/resources/scala-native/external_paths.h
@@ -1,4 +1,4 @@
-//!bindgen: --render.external-path */external_paths.inc.h=lib_test_external_paths_inc.all
+//!bindgen: --render.external-path *external_paths_inc.h=lib_test_external_paths_inc.all
 
 #include "external_paths_inc.h"
 

--- a/modules/tests/src/test/resources/scala-native/external_paths_inc.h
+++ b/modules/tests/src/test/resources/scala-native/external_paths_inc.h
@@ -1,3 +1,8 @@
+#ifndef EXTERNAL_PATHS_INC_H
+#define EXTERNAL_PATHS_INC_H
+
 typedef struct {
     int hello;
 } my_struct;
+
+#endif // EXTERNAL_PATHS_INC_H

--- a/modules/tests/src/test/resources/scala-native/external_paths_inc.h
+++ b/modules/tests/src/test/resources/scala-native/external_paths_inc.h
@@ -1,0 +1,3 @@
+typedef struct {
+    int hello;
+} my_struct;

--- a/modules/tests/src/test/scalanative/TestExternals.scala
+++ b/modules/tests/src/test/scalanative/TestExternals.scala
@@ -1,0 +1,19 @@
+package bindgen
+
+import org.junit.Assert.*
+import org.junit.Test
+
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
+
+class TestExternals:
+  import lib_test_external_paths_inc.all.*
+  import lib_test_external_paths.all.*
+
+  @Test def test_basics() =
+    Zone:
+      val str = my_struct(25)
+      val result = my_func(str)
+
+      assertEquals(result, 25 * 11)
+end TestExternals

--- a/modules/tests/src/test/scalanative/TestExternals.scala
+++ b/modules/tests/src/test/scalanative/TestExternals.scala
@@ -12,7 +12,7 @@ class TestExternals:
 
   @Test def test_basics() =
     Zone:
-      val str = my_struct(25)
+      val str = lib_test_external_paths_inc.structs.my_struct(25)
       val result = my_func(str)
 
       assertEquals(result, 25 * 11)


### PR DESCRIPTION
First they didn't do anything, then they were slightly incorrect because alias resolving needs to happen on full model, not just the filtered down version.

Also weirdly had to add this uncaught exception handler because otherwise the error just didn't appear...