### PR TITLE
Bindgen toString implementation and change how output is read in SBT plugin

### DIFF
--- a/modules/bindgen/src/main/scala/render/BindingInfo.scala
+++ b/modules/bindgen/src/main/scala/render/BindingInfo.scala
@@ -17,13 +17,13 @@ class BindingInfo(rawBinding: Binding)(using Config, Context):
           config.rendering.matchesPackage(_.externalNames)(n)
 
         fileMatches.map((filterSpec, pkg) =>
-          trace(
+          info(
             s"Definition `$n` was not rendered because it matched path " +
               s"filter `$filterSpec`, and will be referenced instead from `$pkg` package"
           )
         ) orElse
           nameMatches.map((filterSpec, pkg) =>
-            trace(
+            info(
               s"Definition `$n` was not rendered because its name matched" +
                 s"filter `$filterSpec`, and will be referenced instead from `$pkg` package"
             )
@@ -32,6 +32,17 @@ class BindingInfo(rawBinding: Binding)(using Config, Context):
       .isEmpty
 
   val binding = rawBinding.filterAll(shouldRender)
+
+  info(
+    "Before filtering: " + rawBinding.structs.exists(
+      _.name == Some(StructName("GInputStream"))
+    )
+  )
+  info(
+    "After filtering: " + binding.structs.exists(
+      _.name == Some(StructName("GInputStream"))
+    )
+  )
 
   // In order
   def anonymousEnumBases(struct: Def.Struct | Def.Union | Def.Enum) =
@@ -94,5 +105,11 @@ class BindingInfo(rawBinding: Binding)(using Config, Context):
   val resolvedUnions = all.collect { case rs: ResolvedUnion => rs }
   val resolvedEnums = all.collect { case rs: ResolvedEnum => rs }
   val aliases = binding.aliases.toList.sortBy(_.name)
+
+  info(
+    "After resolving: " + resolvedStructs.exists(
+      _.name == StructName("GInputStream")
+    )
+  )
 
 end BindingInfo

--- a/modules/bindgen/src/main/scala/render/MultiFileRender.scala
+++ b/modules/bindgen/src/main/scala/render/MultiFileRender.scala
@@ -51,6 +51,7 @@ class MultiFileRender(rawBinding: Binding) extends RenderingBase:
       structs: Iterable[ResolvedStruct]
   )(using Config, AliasResolver, Context) =
     structs.foreach: struct =>
+      info("Rendering struct: " + struct.name)
       val out = stream(struct.name.value)
       StructRenderer(struct, to(out)).render()
 
@@ -59,6 +60,7 @@ class MultiFileRender(rawBinding: Binding) extends RenderingBase:
       unions: Iterable[ResolvedUnion]
   )(using Config, AliasResolver, Context) =
     unions.foreach: union =>
+      info("Rendering union: " + union.name)
       val out = stream(union.name.value)
       UnionRenderer(union, to(out)).render()
 

--- a/modules/bindgen/src/main/scala/render/StructRenderer.scala
+++ b/modules/bindgen/src/main/scala/render/StructRenderer.scala
@@ -22,7 +22,11 @@ private[rendering] class StructRenderer(struct: ResolvedStruct, line: Appender)(
   val madeOpaque = c.rendering.matches(_.opaqueStruct)(structName.value)
 
   val structIsOpaque =
-    if struct.fields.size > 22 then true
+    if struct.fields.size > 22 then
+      warning(
+        s"${structName.value} will be rendered as a static array because it has more than 22 fields"
+      )
+      true
     else if struct.fields.size == 0 then false
     else
       madeOpaque match

--- a/modules/interface/src/main/scala/Binding.scala
+++ b/modules/interface/src/main/scala/Binding.scala
@@ -419,6 +419,103 @@ class Binding private (
   def withBraces(b: Boolean): Binding =
     copy(_.copy(useBraces = b))
 
+  override def toString(): String = {
+    def ifNotEmpty[A](ls: Iterable[A])(f: => Unit): Unit = {
+      if (ls.nonEmpty) f
+    }
+
+    val sb = List.newBuilder[String]
+    sb += "Binding {"
+    sb += s" headerFile: $headerFile"
+    sb += s" packageName: $packageName"
+    sb += s" linkName: $linkName"
+    ifNotEmpty(cImports) {
+      sb += s" cImports: ["
+      cImports.foreach { imp =>
+        sb += s"    $imp"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(clangFlags) {
+      sb += s"  clangFlags: ["
+      clangFlags.foreach { flag =>
+        sb += s"    $flag"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(exclusivePrefixes) {
+      sb += s"  exclusivePrefixes: ["
+      exclusivePrefixes.foreach { prefix =>
+        sb += s"    $prefix"
+      }
+      sb += "  ]"
+    }
+    sb += s"  logLevel: $logLevel"
+    sb += s"  systemIncludes: $systemIncludes"
+    ifNotEmpty(externalPaths) {
+      sb += s"  externalPaths: ["
+      externalPaths.toList.sortBy(_._1).foreach { case (key, value) =>
+        sb += s"    $key -> $value"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(externalNames) {
+      sb += s"  externalNames: ["
+      externalNames.toList.sortBy(_._1).foreach { case (key, value) =>
+        sb += s"    $key -> $value"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(noConstructor) {
+      sb += s"  noConstructor: ["
+      noConstructor.foreach { arg =>
+        sb += s"    $arg"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(excludeSystemPaths) {
+      sb += s"  excludeSystemPaths: ["
+      excludeSystemPaths.foreach { path =>
+        sb += s"    $path"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(opaqueStructs) {
+      sb += s"  opaqueStructs: ["
+      opaqueStructs.foreach { path =>
+        sb += s"    $path"
+      }
+      sb += "  ]"
+    }
+    ifNotEmpty(macroDefinitions) {
+      sb += s"  macroDefinitions: ["
+      macroDefinitions.foreach { path =>
+        sb += s"    $path"
+      }
+      sb += "  ]"
+    }
+    sb += s"  onlyValidMacros: $onlyValidMacros"
+    sb += s"  multiFile: $multiFile"
+    sb += s"  noComments: $noComments"
+    sb += s"  noLocation: $noLocation"
+    sb += s"  exportMode: $exportMode"
+    sb += s"  scalaFile: $scalaFile"
+    sb += s"  cFile: $cFile"
+    sb += s"  flavour: $flavour"
+    sb += s"  useBraces: $useBraces"
+    ifNotEmpty(bindgenArguments) {
+      sb += s"  bindgenArguments: ["
+      bindgenArguments.foreach { arg =>
+        sb += s"    $arg"
+      }
+      sb += "  ]"
+    }
+    sb += "  CMD: " + toCommand(BindingLang.Scala).mkString(" ")
+    sb += "}"
+
+    sb.result().mkString("\n")
+  }
+
   /** Produces a full list of CLI arguments that bindgen should be invoked with,
     * for a given output language
     *

--- a/modules/interface/src/main/scala/BindingBuilder.scala
+++ b/modules/interface/src/main/scala/BindingBuilder.scala
@@ -84,17 +84,36 @@ class BindingBuilder(
       val process = new java.lang.ProcessBuilder(cmd*)
         .start()
 
-      io.Source
-        .fromInputStream(process.getErrorStream())
-        .getLines()
-        .foreach(errPrintln(_))
+      val stdoutReaderThread = new Thread(() => {
 
-      io.Source
-        .fromInputStream(process.getInputStream())
-        .getLines()
-        .foreach(logger.out(_))
+        val reader =
+          new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+        var line = "";
+        while ({ line = reader.readLine(); line } != null) {
+          stdout += line
+        }
+
+      })
+
+      val stderrReaderThread = new Thread(() => {
+
+        val reader =
+          new BufferedReader(new InputStreamReader(process.getErrorStream()));
+
+        var line: String = "";
+        while ({ line = reader.readLine(); line } != null) {
+          errPrintln(line)
+        }
+      })
+
+      stdoutReaderThread.start()
+      stderrReaderThread.start()
 
       val result = process.waitFor()
+
+      stderrReaderThread.join()
+      stdoutReaderThread.join()
 
       files ++= stdout
         .result()

--- a/modules/sbt-plugin/src/main/scala/BindgenPlugin.scala
+++ b/modules/sbt-plugin/src/main/scala/BindgenPlugin.scala
@@ -51,6 +51,15 @@ object BindgenPlugin extends AutoPlugin {
     val bindgenFlavour = settingKey[Flavour](
       s"Bindgen flavour. Default: ${getBindgenFlavour(nativeVersion)}"
     )
+
+    object BindgenTags {
+
+      /** This tag is applied to the [[bindgenGenerateScalaSources]] and
+        * [[bindgenGenerateCSources]] tasks.
+        */
+      val Generate = Tags.Tag("bindgen-generate")
+    }
+
   }
 
   private def getBindgenFlavour(ver: String) =
@@ -190,60 +199,76 @@ object BindgenPlugin extends AutoPlugin {
     ) ++
       Seq(Compile, Test).flatMap(conf => inConfig(conf)(definedSettings(conf)))
 
+  override def globalSettings: Seq[Setting[?]] = Seq(
+    Global / concurrentRestrictions +=
+      Tags.limit(BindgenTags.Generate, 1)
+  )
+
   private def definedSettings(addConf: Configuration) = Seq(
     bindgenGenerateAll := {
       bindgenGenerateScalaSources.value ++ bindgenGenerateCSources.value
     },
-    bindgenGenerateScalaSources := {
-      val selected = (addConf / bindgenBindings).value.map { b =>
-        b.flavour match {
-          case None =>
-            b.withFlavour(bindgenFlavour.value)
-              .withBraces(scalacOptions.value.contains("-no-indent"))
-          case Some(_) =>
-            b.withBraces(scalacOptions.value.contains("-no-indent"))
+    bindgenGenerateScalaSources := Def
+      .task {
+        val selected = (addConf / bindgenBindings).value.map { b =>
+          b.flavour match {
+            case None =>
+              b.withFlavour(bindgenFlavour.value)
+                .withBraces(scalacOptions.value.contains("-no-indent"))
+            case Some(_) =>
+              b.withBraces(scalacOptions.value.contains("-no-indent"))
+          }
         }
-      }
 
-      val managedDestination = sourceManaged.value
+        val managedDestination = sourceManaged.value
 
-      val dest = bindgenMode.value match {
-        case BindgenMode.ResourceGenerator   => managedDestination
-        case BindgenMode.Manual(scalaDir, _) => scalaDir
-      }
-
-      incremental(
-        Config(bindgenVersion.value, bindgenBinary.value),
-        (selected).distinct,
-        dest,
-        BindingLang.Scala,
-        bindgenClangPath.value,
-        streams.value
-      )
-    },
-    bindgenGenerateCSources := {
-      val selected = (addConf / bindgenBindings).value.map { b =>
-        b.flavour match {
-          case None    => b.withFlavour(bindgenFlavour.value)
-          case Some(_) => b
+        val dest = bindgenMode.value match {
+          case BindgenMode.ResourceGenerator   => managedDestination
+          case BindgenMode.Manual(scalaDir, _) => scalaDir
         }
-      }
 
-      val managedDestination = (resourceManaged).value / "scala-native"
+        val targetDir = crossTarget.value / "sn-bindgen"
 
-      val dest = bindgenMode.value match {
-        case BindgenMode.ResourceGenerator => managedDestination
-        case BindgenMode.Manual(_, cDir)   => cDir
+        incremental(
+          Config(bindgenVersion.value, bindgenBinary.value),
+          (selected).distinct,
+          dest,
+          BindingLang.Scala,
+          bindgenClangPath.value,
+          streams.value,
+          targetDir
+        )
       }
-      incremental(
-        Config(bindgenVersion.value, bindgenBinary.value),
-        (selected).distinct,
-        dest,
-        BindingLang.C,
-        bindgenClangPath.value,
-        streams.value
-      )
-    },
+      .tag(BindgenTags.Generate)
+      .value,
+    bindgenGenerateCSources := Def
+      .task {
+        val selected = (addConf / bindgenBindings).value.map { b =>
+          b.flavour match {
+            case None    => b.withFlavour(bindgenFlavour.value)
+            case Some(_) => b
+          }
+        }
+
+        val managedDestination = (resourceManaged).value / "scala-native"
+        val targetDir = crossTarget.value / "sn-bindgen"
+
+        val dest = bindgenMode.value match {
+          case BindgenMode.ResourceGenerator => managedDestination
+          case BindgenMode.Manual(_, cDir)   => cDir
+        }
+        incremental(
+          Config(bindgenVersion.value, bindgenBinary.value),
+          (selected).distinct,
+          dest,
+          BindingLang.C,
+          bindgenClangPath.value,
+          streams.value,
+          targetDir = targetDir
+        )
+      }
+      .tag(BindgenTags.Generate)
+      .value,
     sourceGenerators ++= {
       if (bindgenMode.value.isInstanceOf[BindgenMode.Manual]) Seq.empty
       else Seq(bindgenGenerateScalaSources.taskValue)
@@ -301,7 +326,8 @@ object BindgenPlugin extends AutoPlugin {
       destination: File,
       lang: BindingLang,
       clangPath: java.nio.file.Path,
-      streams: TaskStreams
+      streams: TaskStreams,
+      targetDir: File
   ): Seq[File] = {
 
     import config.*
@@ -334,7 +360,12 @@ object BindgenPlugin extends AutoPlugin {
           (outDiff: ChangeReport[File]) =>
             if (changed || outDiff.modified.nonEmpty) {
               builder
-                .generate(defined, destination, lang, Some(clangPath))
+                .generate(
+                  defined,
+                  destination,
+                  lang,
+                  Some(clangPath)
+                )
                 .toSet
             } else outDiff.checked
         }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.4
+sbt.version=1.12.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.sonatypeCentralSnapshots
 
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.10")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
 
 addSbtPlugin("com.indoorvivants" % "sbt-commandmatrix" % "0.0.5")
 


### PR DESCRIPTION
I struggled to make gtk bindings generation work without this.

Seems like output reading was getting stuck:

```
va.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@21.0.3/Native Method)
        - parking to wait for  <0x000000071591bc30> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(java.base@21.0.3/LockSupport.java:371)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@21.0.3/AbstractQueuedSynchronizer.java:519)
        at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@21.0.3/ForkJoinPool.java:3780)
        at java.util.concurrent.ForkJoinPool.managedBlock(java.base@21.0.3/ForkJoinPool.java:3725)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@21.0.3/AbstractQueuedSynchronizer.java:1707)
        at java.lang.ProcessImpl.waitFor(java.base@21.0.3/ProcessImpl.java:425)
        at bindgen.interface.BindingBuilder.$anonfun$generate$1(BindingBuilder.scala:97)
        at bindgen.interface.BindingBuilder.$anonfun$generate$1$adapted(BindingBuilder.scala:32)
        at bindgen.interface.BindingBuilder$$Lambda/0x0000000801175840.apply(Unknown Source)
        at scala.collection.immutable.List.foreach(List.scala:431)
        at bindgen.interface.BindingBuilder.generate(BindingBuilder.scala:32)
        at bindgen.plugin.BindgenPlugin$.$anonfun$incremental$8(BindgenPlugin.scala:357)
        at bindgen.plugin.BindgenPlugin$$$Lambda/0x0000000801175468.apply(Unknown Source)
        at sbt.util.Difference.apply(Tracked.scala:415)
        at sbt.util.Difference.apply(Tracked.scala:395)
        at bindgen.plugin.BindgenPlugin$.$anonfun$incremental$7(BindgenPlugin.scala:353)
        at bindgen.plugin.BindgenPlugin$.$anonfun$incremental$7$adapted(BindgenPlugin.scala:352)
        at bindgen.plugin.BindgenPlugin$$$Lambda/0x0000000801173cb8.apply(Unknown Source)
        at sbt.util.Tracked$.$anonfun$inputChangedW$1(Tracked.scala:220)
        at sbt.util.Tracked$$$Lambda/0x0000000800a87148.apply(Unknown Source)
        at bindgen.plugin.BindgenPlugin$.incremental(BindgenPlugin.scala:366)
        at bindgen.plugin.BindgenPlugin$.$anonfun$definedSettings$5(BindgenPlugin.scala:262)
        at bindgen.plugin.BindgenPlugin$$$Lambda/0x0000000800f62d50.apply(Unknown Source)

```