### PR TITLE
Let --exclude-system-path override clang's isFromSystemHeader

### DIFF
--- a/modules/bindgen/src/main/scala/analysis/ClangVisitor.scala
+++ b/modules/bindgen/src/main/scala/analysis/ClangVisitor.scala
@@ -29,9 +29,9 @@ object ClangVisitor:
             val filename = loc.getFilename
             Location(
               loc.isFromMainFile,
-              loc.isFromSystemHeader || filename.isEmpty || filename
+              filename.isEmpty || filename
                 .exists(
-                  systemDetector.isSystem
+                  systemDetector.isSystem(_, loc.isFromSystemHeader)
                 )
             )
 

--- a/modules/bindgen/src/main/scala/analysis/SystemHeaderDetector.scala
+++ b/modules/bindgen/src/main/scala/analysis/SystemHeaderDetector.scala
@@ -10,13 +10,14 @@ class SystemHeaderDetector(
   private val includes = clangInfo.includePaths.map(Paths.get(_))
   private val excludes = excludeSystemPaths.map(_.value).map(Paths.get(_))
 
-  def isSystem(filename: String): Boolean =
+  def isSystem(filename: String, isFromClangSystemHeader: Boolean): Boolean =
     val path = java.nio.file.Paths.get(filename)
 
     def isChild(ip: Path) = path.startsWith(ip)
 
     val isInExcludedLocation = excludes.exists(isChild)
-    val isInSystemLocation = includes.exists(isChild)
+    val isInSystemLocation =
+      isFromClangSystemHeader || includes.exists(isChild)
 
     mut.getOrElseUpdate(
       filename,


### PR DESCRIPTION
## Summary

Fixes #361.

`--exclude-system-path` (interface: `Binding.addExcludedSystemPath` / `withExcludedSystemPaths`) is documented as "list of paths to mark as non-system", and `SystemHeaderDetector.isSystem` already returns `false` for excluded paths. But in `ClangVisitor.scala` the detector result was OR'd *after* `loc.isFromSystemHeader`:

```scala
loc.isFromSystemHeader || filename.isEmpty || filename.exists(systemDetector.isSystem)
```

So on platforms where the target headers are tagged `C_System` by clang itself — notably macOS framework headers reached via `<Framework/Header.h>` — the short-circuit made the exclusion unreachable. As @keynmol noted on the issue: "should work but doesn't".

This PR threads `loc.isFromSystemHeader` into the detector so the exclude check covers clang-tagged system headers too. After the change:

- excluded path → not system (NEW: even if clang tagged it)
- not excluded, clang-tagged system → system (unchanged)
- not excluded, inside a clang include search path → system (unchanged)
- otherwise → not system (unchanged)

The `mut` cache key (filename) is still sound because a file's system characteristic is stable across the cursors visited within one translation unit.

## Test plan

- [x] `sbt bindgen/compile` — clean (no new warnings)
- [x] `sbt bindgen/test` — 15/15 pass
- [ ] Reviewer to consider whether a regression test belongs in `modules/tests` (the existing `SystemHeaderDetector` has no direct unit coverage; happy to add one if you'd like a particular shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)