### PR TITLE
Emit bindings for `extern` variable declarations

### DIFF
--- a/docs/pages/semantics.md
+++ b/docs/pages/semantics.md
@@ -264,3 +264,32 @@ val cSource =
 """.trim.stripMargin
 println(bindgen.BindgenRender.render(cSource, "libtest", "--macros", "SDL_*,AUDIO_U8,STR_*,FLT_*"))
 ```
+
+## Extern variable declarations are rendered as `var name: T = extern`
+
+`extern` variable declarations (including `extern const` ones, e.g. CoreFoundation's
+`kSecClass`, `kCFBooleanTrue` or libc's `errno`, `environ`) are collected into an
+`@extern object variables`. Each one becomes a `var` so Scala Native can read it
+(and write it, where the C side declares it mutable) directly from the linked
+library.
+
+By default every `extern` variable declaration found in non-system headers is
+rendered. To restrict the set, pass a name filter:
+
+- In CLI, `--variables 'kSec*,errno'` will render only matching extern variables
+- In SBT, `.withVariables(Set("kSec*", "errno"))` will produce the same result
+
+The C-level `const` qualifier is intentionally dropped on the Scala side –
+Scala Native's `var name: T = extern` is the only available form, and the user
+is expected not to assign to declarations the C library considers immutable.
+
+```scala mdoc:nest:passthrough
+val cSource =
+"""
+|extern const int simple_int_const;
+|extern int writable_int;
+|extern const char *some_string;
+|extern void *some_opaque;
+""".trim.stripMargin
+println(bindgen.BindgenRender.render(cSource, "libtest"))
+```

--- a/modules/bindgen/src/main/scala/Binding.scala
+++ b/modules/bindgen/src/main/scala/Binding.scala
@@ -12,7 +12,7 @@ case class Binding(
     macros: List[MacroDefinition],
     functions: Set[Def.Function],
     unnamedEnums: Set[Def.Enum],
-    variables: Set[Def.Variable] = Set.empty
+    variables: Set[Def.Variable]
 ):
   def resolve(using Config) =
     (aliases ++

--- a/modules/bindgen/src/main/scala/Binding.scala
+++ b/modules/bindgen/src/main/scala/Binding.scala
@@ -11,7 +11,8 @@ case class Binding(
     enums: Set[Def.Enum],
     macros: List[MacroDefinition],
     functions: Set[Def.Function],
-    unnamedEnums: Set[Def.Enum]
+    unnamedEnums: Set[Def.Enum],
+    variables: Set[Def.Variable] = Set.empty
 ):
   def resolve(using Config) =
     (aliases ++
@@ -27,6 +28,7 @@ case class Binding(
       structs = structs.filter(f),
       enums = enums.filter(f),
       functions = functions.filter(f),
-      unnamedEnums = unnamedEnums.filter(f)
+      unnamedEnums = unnamedEnums.filter(f),
+      variables = variables.filter(f)
     )
 end Binding

--- a/modules/bindgen/src/main/scala/BindingBuilder.scala
+++ b/modules/bindgen/src/main/scala/BindingBuilder.scala
@@ -45,6 +45,10 @@ class BindingBuilder(
     case (k, BindingDefinition(item: Def.Function, _)) => item
   }.toSet
 
+  def variables: Set[Def.Variable] = named.collect {
+    case (k, BindingDefinition(item: Def.Variable, _)) => item
+  }.toSet
+
   def build: Binding =
     Binding(
       aliases = this.aliases,
@@ -53,6 +57,7 @@ class BindingBuilder(
       functions = this.functions,
       enums = this.enums,
       macros = this.macros,
-      unnamedEnums = this.unnamedEnums
+      unnamedEnums = this.unnamedEnums,
+      variables = this.variables
     )
 end BindingBuilder

--- a/modules/bindgen/src/main/scala/Def.scala
+++ b/modules/bindgen/src/main/scala/Def.scala
@@ -142,11 +142,11 @@ enum Def(meta: Meta):
 
   def defName: Option[DefName] =
     this match
-      case Alias(name, _, _)    => Some(DefName(name, DefTag.Alias))
-      case u: Union             => u.name.map(n => DefName(n.value, DefTag.Union))
-      case f: Function          => Some(DefName(f.name.value, DefTag.Function))
-      case s: Struct            => s.name.map(n => DefName(n.value, DefTag.Struct))
-      case v: Variable          => Some(DefName(v.name, DefTag.Variable))
+      case Alias(name, _, _) => Some(DefName(name, DefTag.Alias))
+      case u: Union          => u.name.map(n => DefName(n.value, DefTag.Union))
+      case f: Function       => Some(DefName(f.name.value, DefTag.Function))
+      case s: Struct         => s.name.map(n => DefName(n.value, DefTag.Struct))
+      case v: Variable       => Some(DefName(v.name, DefTag.Variable))
       case e: Enum =>
         e.name.map(enumName => DefName(enumName.value, DefTag.Enum))
 

--- a/modules/bindgen/src/main/scala/Def.scala
+++ b/modules/bindgen/src/main/scala/Def.scala
@@ -131,14 +131,22 @@ enum Def(meta: Meta):
 
   case Alias(name: String, underlying: CType, meta: Meta) extends Def(meta)
 
+  case Variable(
+      name: String,
+      typ: CType,
+      isConst: Boolean,
+      meta: Meta
+  ) extends Def(meta)
+
   def metadata: Meta = meta
 
   def defName: Option[DefName] =
     this match
-      case Alias(name, _, _) => Some(DefName(name, DefTag.Alias))
-      case u: Union          => u.name.map(n => DefName(n.value, DefTag.Union))
-      case f: Function       => Some(DefName(f.name.value, DefTag.Function))
-      case s: Struct         => s.name.map(n => DefName(n.value, DefTag.Struct))
+      case Alias(name, _, _)    => Some(DefName(name, DefTag.Alias))
+      case u: Union             => u.name.map(n => DefName(n.value, DefTag.Union))
+      case f: Function          => Some(DefName(f.name.value, DefTag.Function))
+      case s: Struct            => s.name.map(n => DefName(n.value, DefTag.Struct))
+      case v: Variable          => Some(DefName(v.name, DefTag.Variable))
       case e: Enum =>
         e.name.map(enumName => DefName(enumName.value, DefTag.Enum))
 

--- a/modules/bindgen/src/main/scala/DefTag.scala
+++ b/modules/bindgen/src/main/scala/DefTag.scala
@@ -1,7 +1,7 @@
 package bindgen
 
 enum DefTag:
-  case Union, Alias, Struct, Function, Enum
+  case Union, Alias, Struct, Function, Enum, Variable
 
 object DefTag:
-  def all = Set(Union, Alias, Struct, Function, Enum)
+  def all = Set(Union, Alias, Struct, Function, Enum, Variable)

--- a/modules/bindgen/src/main/scala/RenderingConfig.scala
+++ b/modules/bindgen/src/main/scala/RenderingConfig.scala
@@ -11,6 +11,7 @@ object RenderingConfig:
       noConstructor = Set.empty,
       opaqueStruct = Set.empty,
       macroDefs = Set.empty,
+      variables = Set.empty,
       onlyValidMacros = RenderOnlyValidMacros.No,
       comments = RenderComments.Yes,
       location = RenderLocation.No,
@@ -56,10 +57,14 @@ opaque type NoConstructorNameFilter <: NameFilter = NameFilter
 object NoConstructorNameFilter
     extends TotalWrapper[NoConstructorNameFilter, NameFilter]
 
+opaque type VariableNameFilter <: NameFilter = NameFilter
+object VariableNameFilter extends TotalWrapper[VariableNameFilter, NameFilter]
+
 case class RenderingConfig(
     noConstructor: Set[NoConstructorNameFilter],
     opaqueStruct: Set[OpaqueStructNameFilter],
     macroDefs: Set[MacroNameFilter],
+    variables: Set[VariableNameFilter],
     onlyValidMacros: RenderOnlyValidMacros,
     comments: RenderComments,
     location: RenderLocation,

--- a/modules/bindgen/src/main/scala/analysis/ClangVisitor.scala
+++ b/modules/bindgen/src/main/scala/analysis/ClangVisitor.scala
@@ -41,6 +41,24 @@ object ClangVisitor:
             binding.add(function, location)
           end if
 
+          if cursor.kind == CXCursorKind.CXCursor_VarDecl then
+            val storageClass = clang_Cursor_getStorageClass(cursor)
+            val isDefinition = clang_isCursorDefinition(cursor).toInt != 0
+
+            if storageClass == CX_StorageClass.CX_SC_Extern && !isDefinition
+            then
+              val name = cursor.spelling
+              val filter = conf.rendering.variables
+              val passes = filter.isEmpty ||
+                conf.rendering.matches(_.variables)(name).isDefined
+
+              if passes then
+                val variable = visitVariable(cursor)
+                binding.add(variable, location)
+              end if
+            end if
+          end if
+
           if cursor.kind == CXCursorKind.CXCursor_MacroDefinition
           then
             val name = cursor.spelling

--- a/modules/bindgen/src/main/scala/analysis/closure.scala
+++ b/modules/bindgen/src/main/scala/analysis/closure.scala
@@ -69,6 +69,8 @@ def definitionClosure(_d: Def)(using Config): Set[String] =
             case f: Def.Enum => Nil -> f.name.toSet.map(_.value)
             case a: Def.Alias =>
               Nil -> (Set(a.name) ++ referencedNames(a.underlying))
+            case v: Def.Variable =>
+              Nil -> (Set(v.name) ++ referencedNames(v.typ))
           end match
         end val
 

--- a/modules/bindgen/src/main/scala/analysis/visitVariable.scala
+++ b/modules/bindgen/src/main/scala/analysis/visitVariable.scala
@@ -1,0 +1,20 @@
+package bindgen
+
+import libclang.*
+
+import scala.scalanative.unsafe.*
+
+import fluent.*
+
+def visitVariable(cursor: CXCursor)(using Zone, Config): Def.Variable =
+  val typ = clang_getCursorType(cursor)
+  val name = clang_getCursorSpelling(cursor).string
+  val isConst = clang_isConstQualifiedType(typ).toInt != 0
+
+  Def.Variable(
+    name = name,
+    typ = constructType(typ),
+    isConst = isConst,
+    meta = extractMetadata(cursor)
+  )
+end visitVariable

--- a/modules/bindgen/src/main/scala/cli/arguments.scala
+++ b/modules/bindgen/src/main/scala/cli/arguments.scala
@@ -302,6 +302,23 @@ object CLI:
       )
       .withDefault(Set.empty)
 
+    val variables = Opts
+      .option[String](
+        "variables",
+        help =
+          "Comma-separated list of names (or wildcards) of extern variable declarations to render.\n" +
+            "When omitted, every extern variable in non-system headers is rendered.\n" +
+            """examples:
+            --variables errno,environ
+            --variables 'kSec*,kCF*'"""
+      )
+      .map(
+        _.split(",").toSet
+          .map(RenderingConfig.NameFilter(_))
+          .map(VariableNameFilter.apply(_))
+      )
+      .withDefault(Set.empty)
+
     val onlyValidMacros = Opts
       .flag(
         "render.only-valid-macros",
@@ -372,6 +389,7 @@ object CLI:
       noConstructor,
       opaqueStruct,
       macroDefs,
+      variables,
       onlyValidMacros,
       comments,
       location,

--- a/modules/bindgen/src/main/scala/render/BindingInfo.scala
+++ b/modules/bindgen/src/main/scala/render/BindingInfo.scala
@@ -72,6 +72,7 @@ class BindingInfo(rawBinding: Binding)(using Config, Context):
   val hasAliases = binding.aliases.nonEmpty
   val hasUnions = binding.unions.nonEmpty
   val hasStructs = binding.structs.nonEmpty
+  val hasVariables = binding.variables.nonEmpty
   val hasConstants = binding.unnamedEnums.nonEmpty || binding.macros.nonEmpty
   val hasAnyTypes = hasAnyEnums || hasAliases || hasUnions || hasStructs
   val typeImports = TypeImports(

--- a/modules/bindgen/src/main/scala/render/MultiFileRender.scala
+++ b/modules/bindgen/src/main/scala/render/MultiFileRender.scala
@@ -35,6 +35,14 @@ class MultiFileRender(rawBinding: Binding) extends RenderingBase:
         exportMode = info.exportMode
       ).render()
 
+    if info.hasVariables then
+      ScalaVariablesRenderer(
+        out = stream("variables"),
+        variables = info.binding.variables,
+        renderMode = RenderMode.Files,
+        typeImports = info.typeImports
+      ).render()
+
     RenderedOutput.Multi(multi.toMap)
   end render
 

--- a/modules/bindgen/src/main/scala/render/RenderedOutput.scala
+++ b/modules/bindgen/src/main/scala/render/RenderedOutput.scala
@@ -15,6 +15,7 @@ enum RenderedOutput:
 enum Exported:
   case No
   case Yes(as: String)
+  case Var(as: String)
 
 enum RenderMode:
   case Objects, Files

--- a/modules/bindgen/src/main/scala/render/ScalaVariablesRenderer.scala
+++ b/modules/bindgen/src/main/scala/render/ScalaVariablesRenderer.scala
@@ -1,0 +1,50 @@
+package bindgen
+package rendering
+
+class ScalaVariablesRenderer(
+    out: LineBuilder,
+    variables: Set[Def.Variable],
+    renderMode: RenderMode,
+    typeImports: TypeImports
+)(using Config, AliasResolver, Context)
+    extends RenderingBase:
+  def render(): Seq[Exported] =
+    val exported = List.newBuilder[Exported]
+
+    if variables.nonEmpty then
+      val safePackageName = packageName.split('.').last
+
+      val objectHeader = summon[Config].linkName
+        .map(l => s"""@link("$l")\n""")
+        .getOrElse("") +
+        "\n@extern\nobject variables"
+
+      maybeObjectBlock(out, renderMode)(objectHeader) {
+        if renderMode == RenderMode.Objects then typeImports.render(out)
+
+        exported ++= interspeseWithNewlines(
+          out,
+          variables.toList.sortBy(_.name)
+        ): v =>
+          val linkAnnotation = Option
+            .when(renderMode == RenderMode.Files)(
+              summon[Config].linkName
+                .map(l => s"""@link("$l") """)
+            )
+            .flatten
+            .getOrElse("")
+
+          val externAnnotation =
+            Option.when(renderMode == RenderMode.Files)("@extern ").getOrElse("")
+
+          renderComment(to(out), v.meta)
+          to(out)(
+            s"$externAnnotation${linkAnnotation}var ${escape(v.name)}: ${scalaType(v.typ)} = extern"
+          )
+          Exported.Var(v.name)
+      }
+    end if
+
+    exported.result()
+  end render
+end ScalaVariablesRenderer

--- a/modules/bindgen/src/main/scala/render/ScalaVariablesRenderer.scala
+++ b/modules/bindgen/src/main/scala/render/ScalaVariablesRenderer.scala
@@ -35,7 +35,9 @@ class ScalaVariablesRenderer(
             .getOrElse("")
 
           val externAnnotation =
-            Option.when(renderMode == RenderMode.Files)("@extern ").getOrElse("")
+            Option
+              .when(renderMode == RenderMode.Files)("@extern ")
+              .getOrElse("")
 
           renderComment(to(out), v.meta)
           to(out)(

--- a/modules/bindgen/src/main/scala/render/SingleFileRender.scala
+++ b/modules/bindgen/src/main/scala/render/SingleFileRender.scala
@@ -7,10 +7,13 @@ class SingleFileRender(rawBinding: Binding) extends RenderingBase:
 
     given AliasResolver = info.aliasResolver
 
-    val exports = List.newBuilder[(String, String)]
+    val exports = List.newBuilder[(String, Exported)]
 
     def updateExports(location: String, names: Seq[Exported]) =
-      exports ++= names.collect { case Exported.Yes(v) => v }.map(location -> _)
+      exports ++= names.collect {
+        case e: Exported.Yes => location -> e
+        case e: Exported.Var => location -> e
+      }
 
     if summon[Context].lang == Lang.Scala then
       val out = createScalaStream
@@ -84,6 +87,20 @@ class SingleFileRender(rawBinding: Binding) extends RenderingBase:
             renderMode = RenderMode.Objects,
             typeImports = info.typeImports,
             exportMode = info.exportMode
+          ).render()
+        )
+
+        out.emptyLine
+      end if
+
+      if info.hasVariables then
+        updateExports(
+          "variables",
+          ScalaVariablesRenderer(
+            out = out,
+            variables = info.binding.variables,
+            renderMode = RenderMode.Objects,
+            typeImports = info.typeImports
           ).render()
         )
 
@@ -241,12 +258,16 @@ class SingleFileRender(rawBinding: Binding) extends RenderingBase:
 
   private def renderExports(
       out: LineBuilder,
-      exports: List[(String, String)]
+      exports: List[(String, Exported)]
   )(using Config, Context) =
     if exports.nonEmpty then
       maybeObjectBlock(out, RenderMode.Objects)("object all") {
-        exports.distinct.foreach { (scope, name) =>
-          to(out)(s"export _root_.$packageName.$scope.$name")
+        exports.distinct.foreach {
+          case (scope, Exported.Yes(name)) =>
+            to(out)(s"export _root_.$packageName.$scope.$name")
+          case (scope, Exported.Var(name)) =>
+            to(out)(s"export _root_.$packageName.$scope.{$name, ${name}_=}")
+          case (_, Exported.No) =>
         }
       }
 

--- a/modules/interface/src/main/scala/Binding.scala
+++ b/modules/interface/src/main/scala/Binding.scala
@@ -60,6 +60,13 @@ class Binding private (
     */
   def macroDefinitions: Set[String] = impl.macroDefinitions
 
+  /** Wildcard matchers or full names of extern variable declarations that
+    * bindgen will render as `var name: T = extern` inside the generated
+    * `variables` object. When empty (the default), every extern variable in
+    * non-system headers is rendered.
+    */
+  def variables: Set[String] = impl.variables
+
   /** When true, bindgen won't render unsupported macros as a compile-time only
     * artifact (one you can't use, but at least you can find it by name and see
     * what the C definition was)
@@ -300,6 +307,15 @@ class Binding private (
     _.copy(macroDefinitions = names)
   )
 
+  /** See [[variables]]
+    *
+    * @param names
+    * @return
+    */
+  def withVariables(names: Set[String]): Binding = copy(
+    _.copy(variables = names)
+  )
+
   /** See [[onlyValidMacros]]
     *
     * @param b
@@ -494,6 +510,13 @@ class Binding private (
       }
       sb += "  ]"
     }
+    ifNotEmpty(variables) {
+      sb += s"  variables: ["
+      variables.foreach { name =>
+        sb += s"    $name"
+      }
+      sb += "  ]"
+    }
     sb += s"  onlyValidMacros: $onlyValidMacros"
     sb += s"  multiFile: $multiFile"
     sb += s"  noComments: $noComments"
@@ -560,6 +583,9 @@ class Binding private (
     if (macroDefinitions.nonEmpty)
       arg("macros", macroDefinitions.toList.sorted.mkString(","))
 
+    if (variables.nonEmpty)
+      arg("variables", variables.toList.sorted.mkString(","))
+
     flag(logLevel.str)
     if (lang == BindingLang.Scala)
       flag("scala")
@@ -622,6 +648,7 @@ object Binding {
       noConstructor: Set[String] = Defaults.noConstructor,
       opaqueStructs: Set[String] = Defaults.opaqueStructs,
       macroDefinitions: Set[String] = Defaults.macroDefinitions,
+      variables: Set[String] = Defaults.variables,
       onlyValidMacros: Boolean = Defaults.onlyValidMacros,
       multiFile: Boolean = Defaults.multiFile,
       noComments: Boolean = Defaults.noComments,
@@ -646,6 +673,7 @@ object Binding {
     val noConstructor = Set.empty[String]
     val opaqueStructs = Set.empty[String]
     val macroDefinitions = Set.empty[String]
+    val variables = Set.empty[String]
     val onlyValidMacros = false
     val exclusivePrefixes = List.empty[String]
     val multiFile = false

--- a/modules/tests/src/test/resources/scala-native/extern_globals.c
+++ b/modules/tests/src/test/resources/scala-native/extern_globals.c
@@ -1,0 +1,8 @@
+#include "extern_globals.h"
+
+const int simple_int_const = 42;
+int writable_int = 7;
+const char *some_string = "hello extern";
+
+static int opaque_sentinel = 99;
+void *some_opaque = &opaque_sentinel;

--- a/modules/tests/src/test/resources/scala-native/extern_globals.h
+++ b/modules/tests/src/test/resources/scala-native/extern_globals.h
@@ -1,0 +1,4 @@
+extern const int simple_int_const;
+extern int writable_int;
+extern const char *some_string;
+extern void *some_opaque;

--- a/modules/tests/src/test/scalanative/TestExternGlobals.scala
+++ b/modules/tests/src/test/scalanative/TestExternGlobals.scala
@@ -28,3 +28,4 @@ class TestExternGlobals:
 
   @Test def test_some_opaque_not_null(): Unit =
     assertNotEquals(null, some_opaque)
+end TestExternGlobals

--- a/modules/tests/src/test/scalanative/TestExternGlobals.scala
+++ b/modules/tests/src/test/scalanative/TestExternGlobals.scala
@@ -1,0 +1,30 @@
+package bindgen
+
+import org.junit.Assert.*
+import org.junit.Test
+
+import scala.scalanative.unsafe.*
+import scala.scalanative.unsigned.*
+
+class TestExternGlobals:
+  import lib_test_extern_globals.all.*
+
+  @Test def test_simple_int_const(): Unit =
+    assertEquals(42, simple_int_const)
+
+  @Test def test_writable_int_initial(): Unit =
+    assertEquals(7, writable_int)
+
+  @Test def test_writable_int_mutates(): Unit =
+    val previous = writable_int
+    try
+      writable_int = 123
+      assertEquals(123, writable_int)
+    finally writable_int = previous
+
+  @Test def test_some_string(): Unit =
+    Zone:
+      assertEquals("hello extern", fromCString(some_string))
+
+  @Test def test_some_opaque_not_null(): Unit =
+    assertNotEquals(null, some_opaque)


### PR DESCRIPTION
Generates `var name: T = extern` declarations for C `extern` variable declarations (including `extern const` ones, e.g. CoreFoundation's `kSecClass` or libc's `errno`). Collected into an `@extern object variables` and re-exported through `object all` with both getter and setter selectors so writes survive the re-export.

By default every extern variable declaration in non-system headers is rendered (mirroring the function default rather than the macro opt-in default). The set can be restricted with `--variables` on the CLI or `.withVariables(Set(...))` via the sbt plugin.

Closes #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)